### PR TITLE
Fix Debian package name, fix top-scope for facts

### DIFF
--- a/manifests/bond.pp
+++ b/manifests/bond.pp
@@ -147,7 +147,7 @@ define network::bond(
     ensure => $ensure,
   }
 
-  case $osfamily {
+  case $::osfamily {
     Debian: {
       network::bond::debian { $name:
         slaves    => $slaves,
@@ -193,7 +193,7 @@ define network::bond(
       }
     }
     default: {
-      fail("network::bond does not support osfamily '${osfamily}'")
+      fail("network::bond does not support osfamily '${::osfamily}'")
     }
   }
 }

--- a/manifests/bond/setup.pp
+++ b/manifests/bond/setup.pp
@@ -1,6 +1,6 @@
 class network::bond::setup {
 
-  case $osfamily {
+  case $::osfamily {
     RedHat: {
       # Redhat installs the ifenslave command with the iputils package which
       # is available by default


### PR DESCRIPTION
Following few changes fixes:
1. Debian/Ubuntu package full name, which is "ifenslave-2.6", not just "ifenslave". With incomplete name Puppet tries to install package in each run. In package details you can see "-2.6" suffix is part of package name, not package version:
   
   Package: ifenslave-2.6
   Status: install ok installed
   Priority: optional
   Section: net
   Installed-Size: 100
   Maintainer: Guus Sliepen guus@debian.org
   Architecture: amd64
   Version: 1.1.0-20
   ...
2. Top-level scope ($::xyz) has been set for facts.
