### PR TITLE
Two fixes for RedHat:

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,14 +52,14 @@ Route configuration
       ensure    => 'present',
       gateway   => '10.0.2.2',
       interface => 'eth0',
-      netmask   => '24',
+      netmask   => '255.255.255.0',
       network   => '172.17.67.0'
     }
     network_route { 'default':
       ensure    => 'present',
       gateway   => '10.0.2.2',
       interface => 'eth0',
-      netmask  	=> '',
+      netmask  	=> '0.0.0.0',
       network   => 'default'
     }
   

--- a/lib/puppet/provider/network_route/redhat.rb
+++ b/lib/puppet/provider/network_route/redhat.rb
@@ -77,7 +77,7 @@ Puppet::Type.type(:network_route).provide(:redhat) do
     # Build routes
     providers.sort_by(&:name).each do |provider|
       [:network, :netmask, :gateway, :interface].each do |prop|
-        raise Puppet::Error, "#{provider.name} does not have a #{property}." if provider.send(prop).nil?
+        raise Puppet::Error, "#{provider.name} does not have a #{prop}." if provider.send(prop).nil?
       end
       if provider.network == "default"
         contents << "#{provider.network} via #{provider.gateway} dev #{provider.interface}\n"


### PR DESCRIPTION
- `property` was renamed to `prop`, so fix the error message
- the `netmask` as described in the README doesn't work on RedHat:
  `NoMethodError: undefined method 'length' for 24:Fixnum`
  so use the "Debian-style" notation there too.
