### PR TITLE
Prevent restarting the network every time puppet runs b/c of default netmask

### DIFF
--- a/lib/puppet/provider/network_route/redhat.rb
+++ b/lib/puppet/provider/network_route/redhat.rb
@@ -49,7 +49,7 @@ Puppet::Type.type(:network_route).provide(:redhat) do
 
         new_route[:name]    = cidr_target
         new_route[:network] = "default"
-        new_route[:netmask] = ''
+        new_route[:netmask] = '0.0.0.0'
         new_route[:gateway] = route[2]
         new_route[:interface] = route[4]
       else


### PR DESCRIPTION
Since we retrieve the default netmask as '' but couldn't handle setting it
as '' we defaulted to '0.0.0.0' and ended up changing the netmask every single
puppet run. And thus we ended up restarting the network every time puppet ran.
Notice: /Stage[main]/Networks::Route/Network_route[default]/netmask: netmask changed '' to '0.0.0.0'
