### PR TITLE
Work around bug in filemapper?

### DIFF
--- a/lib/puppet/provider/network_route/redhat.rb
+++ b/lib/puppet/provider/network_route/redhat.rb
@@ -17,6 +17,7 @@ Puppet::Type.type(:network_route).provide(:redhat) do
   defaultfor :osfamily => :redhat
 
   def select_file
+    return nil unless @resource[:interface]
     "/etc/sysconfig/network-scripts/route-#{@resource[:interface]}"
   end
 


### PR DESCRIPTION
This is a workaround that will solve an issue I ran into and it should also fix #64 and #66. This might be a bug in filemapper, but I'm not sure. It seems like `select_file` gets called one too many times. I dropped a debug line in this method and I see the expected values of the resource `interface` plus one extra call where `interface` is nil. When `interface` is nil, a partial file path gets passed back. If we return nil from the whole method everything is happy.
