### PR TITLE
RHEL7/ CentOS7: adapt ifcfg detection to new device naming scheme

### DIFF
--- a/lib/puppet/provider/network_config/redhat.rb
+++ b/lib/puppet/provider/network_config/redhat.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:network_config).provide(:redhat) do
   VLAN_RANGE_REGEX = %r[\d{1,3}|40[0-9][0-5]]
 
   # @return [Regexp] The regular expression for interface scripts on redhat systems
-  SCRIPT_REGEX     = %r[\Aifcfg-[a-z]+\d+(?::\d+|\.#{VLAN_RANGE_REGEX})?\Z]
+  SCRIPT_REGEX     = %r[\Aifcfg-[a-z]+[a-z\d]+(?::\d+|\.#{VLAN_RANGE_REGEX})?\Z]
 
   NAME_MAPPINGS = {
     :ipaddress  => 'IPADDR',


### PR DESCRIPTION
Since CentOS7, network device naming uses a new naming scheme that derives the name from (among
other things) the PCI port in which the card resides. This allows names such as enp2s0f0 which don't
fit the current expression for detecting interface files.
