### PR TITLE
remove network_public_ip fact

### DIFF
--- a/lib/facter/network.rb
+++ b/lib/facter/network.rb
@@ -2,16 +2,6 @@ require 'facter'
 require 'open-uri'
 require 'timeout'
 
-#Public IP
-# Expected output: The public ipaddress of this node.
-Facter.add("network_public_ip") do
-  setcode do
-    Timeout::timeout(2) do
-      open('http://ip-echo.appspot.com', 'User-Agent' => 'Ruby/Facter').read.match(/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/).to_s
-    end
-  end
-end
-
 #Gateway
 # Expected output: The ip address of the nexthop/default router
 Facter.add("network_nexthop_ip") do

--- a/spec/unit/network_facts_spec.rb
+++ b/spec/unit/network_facts_spec.rb
@@ -1,16 +1,6 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
 require 'open-uri'
-  describe 'network_facts' do
-    describe 'network_public_ip fact' do
-      before do
-        Facter::Util::Resolution.any_instance.stubs(:open).returns(stub(:read => '1.1.1.1'))
-      end
-      it "should be our public ip" do
-        Facter.fact(:network_public_ip).value.should == '1.1.1.1'
-      end
-    end
-  end
   describe 'network_nexthop_ip' do
     before do
       Facter.fact(:kernel).stubs(:value).returns('linux')


### PR DESCRIPTION
this fact seems to be going against the general philosophy and
methodology of the module: it's accessing an external unknown and
potentially untrusted third-party services.

as there is no way to partially disable facts in puppet, it is probably
better, albeit more conservative, to remove this fact.
