### PR TITLE
indent sub-entries to the in interfaces

### DIFF
--- a/lib/puppet/provider/network_config/interfaces.rb
+++ b/lib/puppet/provider/network_config/interfaces.rb
@@ -279,9 +279,9 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
       if provider.options
         provider.options.each_pair do |key, val|
           if val.is_a? String
-            stanza << "#{key} #{val}"
+            stanza << "    #{key} #{val}"
           elsif val.is_a? Array
-            val.each { |entry| stanza << "#{key} #{entry}" }
+            val.each { |entry| stanza << "    #{key} #{entry}" }
           else
             raise Puppet::Error, "#{self} options key #{key} expects a String or Array, got #{val.class}"
           end

--- a/spec/unit/provider/network_config/interfaces_spec.rb
+++ b/spec/unit/provider/network_config/interfaces_spec.rb
@@ -237,7 +237,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
         end
 
         it "should write the value as an modified string" do
-          content.scan(/^pre-up .*$/).first.should == "pre-up /bin/touch /tmp/eth1-up"
+          content.scan(/^\s*pre-up .*$/).first.should == "    pre-up /bin/touch /tmp/eth1-up"
         end
       end
 
@@ -247,8 +247,8 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
         end
 
         it "should write the values in order" do
-          content.scan(/^post-down .*$/)[0].should == "post-down /bin/touch /tmp/eth1-down1"
-          content.scan(/^post-down .*$/)[1].should == "post-down /bin/touch /tmp/eth1-down2"
+          content.scan(/^\s*post-down .*$/)[0].should == "    post-down /bin/touch /tmp/eth1-down1"
+          content.scan(/^\s*post-down .*$/)[1].should == "    post-down /bin/touch /tmp/eth1-down2"
         end
       end
     end


### PR DESCRIPTION
debian's documentation recommends indenting sub-entries in
network/interfaces, so we'll do that too.
