### PR TITLE
add vlan_raw_device explicitely only if in ethXX.NN scenario.

### DIFF
--- a/lib/puppet/provider/network_config/interfaces.rb
+++ b/lib/puppet/provider/network_config/interfaces.rb
@@ -281,7 +281,7 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
         vlan_range_regex = %r[\d{1,3}|40[0-9][0-5]]
         raw_device = provider.name.match(%r[\A([a-z]+\d+)(?::\d+|\.#{vlan_range_regex})?\Z])[1]
 
-        stanza << %{vlan-raw-device #{raw_device}} 
+        stanza << %{vlan-raw-device #{raw_device}} if ! raw_device.match(/^vlan[0-9]{1,}/)
       end
 
       [

--- a/lib/puppet/provider/network_config/interfaces.rb
+++ b/lib/puppet/provider/network_config/interfaces.rb
@@ -226,6 +226,7 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
             when 'netmask';         Instance[name].netmask      = val
             when 'mtu';             Instance[name].mtu          = val
             when 'vlan-raw-device'; Instance[name].mode         = :vlan
+                                    Instance[name].options[key] << val
             else                    Instance[name].options[key] << val
             end
           else
@@ -281,7 +282,10 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
         vlan_range_regex = %r[\d{1,3}|40[0-9][0-5]]
         raw_device = provider.name.match(%r[\A([a-z]+\d+)(?::\d+|\.#{vlan_range_regex})?\Z])[1]
 
-        stanza << %{vlan-raw-device #{raw_device}} if ! raw_device.match(/^vlan[0-9]{1,}/)
+        if ! raw_device.match(/^vlan[0-9]{1,}/)
+          stanza << %{vlan-raw-device #{raw_device}} 
+          provider.options.delete("vlan-raw-device")
+        end
       end
 
       [

--- a/spec/fixtures/provider/network_config/interfaces_spec/two_interfaces_dhcp_vlan
+++ b/spec/fixtures/provider/network_config/interfaces_spec/two_interfaces_dhcp_vlan
@@ -1,0 +1,14 @@
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# The primary network interface
+allow-hotplug eth0
+iface eth0 inet dhcp
+
+allow-auto vlan10
+iface vlan10 inet dhcp
+  vlan-raw-device eth0

--- a/spec/unit/provider/network_config/interfaces_spec.rb
+++ b/spec/unit/provider/network_config/interfaces_spec.rb
@@ -141,6 +141,25 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
       }
     end
 
+    it "should parse out vlanNN iface lines" do
+      fixture = fixture_data('two_interfaces_dhcp_vlan')
+      data = described_class.parse_file('', fixture)
+      
+      data.find { |h| h[:name] == "eth0" }[:hotplug].should be_true
+      data.find { |h| h[:name] == "vlan10" }.should == {
+        :name      => "vlan10",
+        :family    => "inet",
+        :method    => "dhcp",
+        :mode      => :vlan,
+        :onboot    => true,
+        :options   => {
+          "vlan-raw-device" => "eth0",
+        }
+      }
+    end
+
+
+
     describe "when reading an invalid interfaces" do
 
       it "with misplaced options should fail" do


### PR DESCRIPTION
This is a quick fix to make the perfectly official and supported Debian interface syntax for VLANs names *vlanNN* work again after the vlan feature was merged in the provider. Because otherwise in the *vlanNN* stanza a "vlan-raw-device vlanNN" is always added, which breaks the stanza and the vlan configuration.
