### PR TITLE
Ignore new Debian Jessie's features

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,7 +31,9 @@ Metrics/ClassLength:
   Enabled: false
 
 # dealbreaker:
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  Enabled: false
+Style/TrailingCommaInArguments:
   Enabled: false
 Style/ClosingParenthesisIndentation:
   Enabled: false

--- a/lib/puppet/provider/network_config/interfaces.rb
+++ b/lib/puppet/provider/network_config/interfaces.rb
@@ -79,11 +79,11 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
 
     def squeeze_options
       @options.each_with_object({}) do |(key, value), hash|
-        if value.size <= 1
-          hash[key] = value.pop
-        else
-          hash[key] = value
-        end
+        hash[key] = if value.size <= 1
+                      value.pop
+                    else
+                      value
+                    end
         hash
       end
     end
@@ -123,7 +123,6 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
     # parsed.
     status = :none
     current_interface = nil
-
     lines = contents.split("\n")
     # TODO: Join lines that end with a backslash
 
@@ -135,6 +134,11 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
       case line
       when /^\s*#|^\s*$/
         # Ignore comments and blank lines
+        next
+
+      when /^source|^source-directory/
+        # ignore source|source-directory sections, it makes this provider basically useless
+        # with Debian Jessie. Please refer to man 5 interfaces
         next
 
       when /^auto|^allow-auto/

--- a/lib/puppet/provider/network_config/redhat.rb
+++ b/lib/puppet/provider/network_config/redhat.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:network_config).provide(:redhat) do
   has_feature :provider_options
 
   # @return [String] The path to network-script directory on redhat systems
-  SCRIPT_DIRECTORY = '/etc/sysconfig/network-scripts'
+  SCRIPT_DIRECTORY = '/etc/sysconfig/network-scripts'.freeze
 
   # The valid vlan ID range is 0-4095; 4096 is out of range
   VLAN_RANGE_REGEX = /\d{1,3}|40[0-9][0-5]/
@@ -35,7 +35,7 @@ Puppet::Type.type(:network_config).provide(:redhat) do
     :name       => 'DEVICE',
     :hotplug    => 'HOTPLUG',
     :mtu        => 'MTU',
-  }
+  }.freeze
 
   # Map provider instances to files based on their name
   #
@@ -89,7 +89,7 @@ Puppet::Type.type(:network_config).provide(:redhat) do
     # Strip out all comments
     lines.map! { |line| line.sub(/#.*$/, '') }
     # Remove all blank lines
-    lines.reject! { |line| line.match(/^\s*$/) }
+    lines.reject! { |line| line =~ /^\s*$/ }
 
     pair_regex = /^\s*(.+?)\s*=\s*(.*)\s*$/
 
@@ -117,11 +117,11 @@ Puppet::Type.type(:network_config).provide(:redhat) do
     # issue that caused this, and https://github.com/adrienthebo/puppet-network/issues/16
     # for the resolution.
     #
-    props.merge!(:family => :inet)
+    props[:family] = :inet
 
     # If there is no DEVICE property in the interface configuration we retrieve
     # the interface name from the file name itself
-    props.merge!(:name => filename.split('ifcfg-')[1]) unless props.key?(:name)
+    props[:name] = filename.split('ifcfg-')[1] unless props.key?(:name)
 
     # The FileMapper mixin expects an array of providers, so we return the
     # single interface wrapped in an array

--- a/lib/puppet/provider/network_route/redhat.rb
+++ b/lib/puppet/provider/network_route/redhat.rb
@@ -83,11 +83,11 @@ Puppet::Type.type(:network_route).provide(:redhat) do
       [:network, :netmask, :gateway, :interface].each do |prop|
         fail Puppet::Error, "#{provider.name} does not have a #{prop}." if provider.send(prop).nil?
       end
-      if provider.network == 'default'
-        contents << "#{provider.network} via #{provider.gateway} dev #{provider.interface} #{provider.options}\n"
-      else
-        contents << "#{provider.network}/#{provider.netmask} via #{provider.gateway} dev #{provider.interface} #{provider.options}\n"
-      end
+      contents << if provider.network == 'default'
+                    "#{provider.network} via #{provider.gateway} dev #{provider.interface} #{provider.options}\n"
+                  else
+                    "#{provider.network}/#{provider.netmask} via #{provider.gateway} dev #{provider.interface} #{provider.options}\n"
+                  end
     end
     contents.join
   end

--- a/lib/puppet/type/network_config.rb
+++ b/lib/puppet/type/network_config.rb
@@ -91,7 +91,7 @@ Puppet::Type.newtype(:network_config) do
       # is 42 with a 802.1q header and 46 without.
       min_mtu = 42
       max_mtu = 65_536
-      unless (min_mtu..max_mtu).include?(value.to_i)
+      unless (min_mtu..max_mtu).cover?(value.to_i)
         fail ArgumentError, "#{value} is not in the valid mtu range (#{min_mtu} .. #{max_mtu})"
       end
     end

--- a/spec/fixtures/provider/network_config/interfaces_spec/jessie_source_stanza
+++ b/spec/fixtures/provider/network_config/interfaces_spec/jessie_source_stanza
@@ -1,0 +1,13 @@
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+source /etc/network/interfaces.d/*
+source-directory /etc/network/custom-ifaces
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# The primary network interface
+allow-hotplug eth0
+iface eth0 inet dhcp

--- a/spec/unit/provider/network_config/interfaces_spec.rb
+++ b/spec/unit/provider/network_config/interfaces_spec.rb
@@ -51,6 +51,17 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
                                                          :options => {},)
     end
 
+    it 'should ignore source and source-directory lines' do
+      fixture = fixture_data('jessie_source_stanza')
+      data = described_class.parse_file('', fixture)
+      expect(data.find { |h| h[:name] == 'eth0' }).to eq(:family  => 'inet',
+                                                         :method  => 'dhcp',
+                                                         :mode    => :raw,
+                                                         :name    => 'eth0',
+                                                         :hotplug => true,
+                                                         :options => {},)
+    end
+
     it 'should ignore variable whitespace in iface lines (network-#26)' do
       fixture = fixture_data('iface_whitespace')
       data = described_class.parse_file('', fixture)

--- a/spec/unit/provider/network_config/redhat_spec.rb
+++ b/spec/unit/provider/network_config/redhat_spec.rb
@@ -399,8 +399,8 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
            :netmask   => '255.255.255.0',
            :method    => 'static',
            :mtu       => '1500',
-           :mode            => nil,
-           :options   => {
+           :mode => nil,
+           :options => {
              'BONDING_OPTS' => %(mode=4 miimon=100 xmit_hash_policy=layer3+4)
            }
 


### PR DESCRIPTION
The `source` and `source-directory` stanzas in Debian Jessie
interfaces(5) make this provider basically useless, as we could
reimplement everything as a "interface fragment" in the `interfaces.d`
directory, with one interface per file. Knowing that this would be a
BIG refactor, I prefer to ignore theses stanzas and use the classic
method