### PR TITLE
Changes to network_config redhat provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ spec/fixtures
 .rspec_system
 .vagrant
 Gemfile.lock
+log/
+spec/acceptance/nodesets/default.yml
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ script:
 matrix:
   fast_finish: true
   include:
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.4" CHECK=test
   - rvm: 1.9.3
     env: PUPPET_VERSION="~> 3.4" CHECK=test
   - rvm: 1.9.3

--- a/lib/puppet/provider/network_config/interfaces.rb
+++ b/lib/puppet/provider/network_config/interfaces.rb
@@ -275,7 +275,7 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
       [
         [:ipaddress, 'address'],
         [:netmask,   'netmask'],
-        [:mtu,       'mtu'],
+        [:mtu,       'mtu']
       ].each do |(property, section)|
         stanza << "#{section} #{provider.send property}" if provider.send(property) && provider.send(property) != :absent
       end

--- a/spec/acceptance/network_spec.rb
+++ b/spec/acceptance/network_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper_acceptance'
+
+describe 'network' do
+  describe 'building various network configurations' do
+    it 'should work with no errors' do
+      pp = <<-EOS
+network_config { 'eth0':
+  ensure      => present,
+  onboot      => 'yes',
+  ipaddress   => undef,
+  netmask     => undef,
+  method      => 'none',
+  mtu         => undef,
+  reconfigure => false,
+  options     => {
+    type   => 'Ethernet',
+    slave  => 'yes',
+    master => 'bond0',
+  }
+}
+network_config { 'bond0':
+  ensure      => present,
+  onboot      => 'yes',
+  ipaddress   => '192.168.0.1',
+  netmask     => '255.255.255.0',
+  options     => {
+    type         => 'Bonding',
+    bonding_opts => 'mode=4 miimon=100 xmit_hash_policy=layer3+4',
+  }
+}
+      EOS
+      # run twice, test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
+    end
+    describe file('/etc/sysconfig/network-scripts/ifcfg-eth0') do
+      it { should be_file }
+      its(:content) { should match(/^DEVICE=eth0$/) }
+      its(:content) { should match(/^TYPE=Ethernet$/) }
+      its(:content) { should match(/^ONBOOT=yes$/) }
+      its(:content) { should_not match(/^IPADDR=/) }
+      its(:content) { should_not match(/^GATEWAY=/) }
+      its(:content) { should_not match(/^BROADCAST=/) }
+      its(:content) { should_not match(/^NETMASK=/) }
+      its(:content) { should_not match(/^MTU=/) }
+    end
+
+    describe file('/etc/sysconfig/network-scripts/ifcfg-bond0') do
+      its(:content) { should match(/^DEVICE=bond0$/) }
+      its(:content) { should match(/^TYPE=Bonding$/) }
+      its(:content) { should match(/^ONBOOT=yes$/) }
+      its(:content) { should match(/^IPADDR=192\.168\.0\.1$/) }
+      its(:content) { should match(/^NETMASK=255\.255\.255\.0$/) }
+      its(:content) { should match(/^BONDING_OPTS="mode=4 miimon=100 xmit_hash_policy=layer3\+4"$/) }
+      its(:content) { should_not match(/^MTU=/) }
+    end
+  end
+end

--- a/spec/defines/bond/debian_spec.rb
+++ b/spec/defines/bond/debian_spec.rb
@@ -19,7 +19,7 @@ describe 'network::bond::debian', :type => :define do
         'lacp_rate'        => 'slow',
         'primary'          => 'eth0',
         'primary_reselect' => 'always',
-        'xmit_hash_policy' => 'layer2',
+        'xmit_hash_policy' => 'layer2'
       }
     end
 
@@ -43,8 +43,8 @@ describe 'network::bond::debian', :type => :define do
                                                     'bond-lacp-rate'        => 'slow',
                                                     'bond-primary'          => 'eth0',
                                                     'bond-primary-reselect' => 'always',
-                                                    'bond-xmit-hash-policy' => 'layer2',
-                                                  },)
+                                                    'bond-xmit-hash-policy' => 'layer2'
+                                                  })
     end
   end
 
@@ -65,7 +65,7 @@ describe 'network::bond::debian', :type => :define do
         'downdelay'        => '100',
         'updelay'          => '100',
         'lacp_rate'        => 'fast',
-        'xmit_hash_policy' => 'layer3+4',
+        'xmit_hash_policy' => 'layer3+4'
       }
     end
     %w(eth0 eth1 eth2).each do |slave|
@@ -89,7 +89,7 @@ describe 'network::bond::debian', :type => :define do
                                                     'bond-lacp-rate'        => 'fast',
                                                     'bond-xmit-hash-policy' => 'layer3+4',
                                                     'bond-future-option'    => 'yes'
-                                                  },)
+                                                  })
     end
   end
 end

--- a/spec/defines/bond/redhat_spec.rb
+++ b/spec/defines/bond/redhat_spec.rb
@@ -19,7 +19,7 @@ describe 'network::bond::redhat', :type => :define do
         'lacp_rate'        => 'slow',
         'primary'          => 'eth0',
         'primary_reselect' => 'always',
-        'xmit_hash_policy' => 'layer2',
+        'xmit_hash_policy' => 'layer2'
       }
     end
 
@@ -31,8 +31,8 @@ describe 'network::bond::redhat', :type => :define do
                                                   'hotplug' => false,
                                                   'options'  => {
                                                     'MASTER' => 'bond0',
-                                                    'SLAVE'  => 'yes',
-                                                  },)
+                                                    'SLAVE'  => 'yes'
+                                                  })
       end
     end
 
@@ -42,8 +42,8 @@ describe 'network::bond::redhat', :type => :define do
                                                   'ipaddress'      => '172.18.1.2',
                                                   'netmask'        => '255.255.128.0',
                                                   'options'        => {
-                                                    'BONDING_OPTS' => 'mode=active-backup miimon=100 downdelay=200 updelay=200 lacp_rate=slow primary=eth0 primary_reselect=always xmit_hash_policy=layer2',
-                                                  },)
+                                                    'BONDING_OPTS' => 'mode=active-backup miimon=100 downdelay=200 updelay=200 lacp_rate=slow primary=eth0 primary_reselect=always xmit_hash_policy=layer2'
+                                                  })
     end
   end
 
@@ -64,7 +64,7 @@ describe 'network::bond::redhat', :type => :define do
         'downdelay'        => '100',
         'updelay'          => '100',
         'lacp_rate'        => 'fast',
-        'xmit_hash_policy' => 'layer3+4',
+        'xmit_hash_policy' => 'layer3+4'
       }
     end
     %w(eth0 eth1 eth2).each do |slave|
@@ -76,8 +76,8 @@ describe 'network::bond::redhat', :type => :define do
                                                   'options' => {
                                                     'MASTER'        => 'bond0',
                                                     'SLAVE'         => 'yes',
-                                                    'NM_CONTROLLED' => 'no',
-                                                  },)
+                                                    'NM_CONTROLLED' => 'no'
+                                                  })
       end
     end
 
@@ -89,8 +89,8 @@ describe 'network::bond::redhat', :type => :define do
                                                   'hotplug'   => false,
                                                   'options'   => {
                                                     'BONDING_OPTS'  => 'mode=balance-rr miimon=50 downdelay=100 updelay=100 lacp_rate=fast xmit_hash_policy=layer3+4',
-                                                    'NM_CONTROLLED' => 'yes',
-                                                  },)
+                                                    'NM_CONTROLLED' => 'yes'
+                                                  })
     end
   end
 end

--- a/spec/defines/bond_spec.rb
+++ b/spec/defines/bond_spec.rb
@@ -20,7 +20,7 @@ describe 'network::bond', :type => :define do
       'lacp_rate'        => 'slow',
       'primary'          => 'eth0',
       'primary_reselect' => 'always',
-      'xmit_hash_policy' => 'layer2',
+      'xmit_hash_policy' => 'layer2'
     }
   end
 
@@ -29,7 +29,7 @@ describe 'network::bond', :type => :define do
       let(:facts) do
         {
           :osfamily      => 'RedHat',
-          :augeasversion => '1.4.0',
+          :augeasversion => '1.4.0'
         }
       end
 
@@ -46,7 +46,7 @@ describe 'network::bond', :type => :define do
       let(:facts) do
         {
           :osfamily      => 'Debian',
-          :augeasversion => '1.4.0',
+          :augeasversion => '1.4.0'
         }
       end
 
@@ -72,7 +72,7 @@ describe 'network::bond', :type => :define do
     let(:facts) do
       {
         :osfamily      => 'Debian',
-        :augeasversion => '1.4.0',
+        :augeasversion => '1.4.0'
       }
     end
 
@@ -80,7 +80,7 @@ describe 'network::bond', :type => :define do
 
     it 'should add a kernel module alias for the bonded device' do
       should contain_kmod__alias('bond0').with(:source => 'bonding',
-                                               :ensure => 'present',)
+                                               :ensure => 'present')
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,78 @@
+require 'beaker-rspec'
+require 'pry'
+test_name 'spec_helper_acceptance'
+
+UNSUPPORTED_PLATFORMS = %w(Windows Solaris AIX).freeze
+
+config = {
+  'main' => {
+    # 'storeconfigs' => 'true',
+  }
+}
+
+unless ENV['BEAKER_provision'] == 'no'
+  hosts.each do |host|
+    step "Installing puppet on \'#{host}\'"
+    # Install Puppet
+    install_puppet_on(host, :version => '3.8.1')
+    configure_puppet_on(host, config)
+    pv = host.execute('puppet --version')
+    step "Puppet Version: \'#{pv}\'"
+
+    # LB: Gem 'ipaddress' required for voxpupuli/puppet-network Types to work
+    host.execute('gem install ipaddress')
+
+    # Required for binding tests.
+    next unless fact('osfamily') == 'RedHat'
+    version = fact('operatingsystemmajrelease')
+    host.execute("yum localinstall -y http://yum.puppetlabs.com/puppetlabs-release-el-#{version}.noarch.rpm")
+    host.execute('yum install -y tar git vim')
+    if fact('operatingsystemmajrelease') =~ /7/ || fact('operatingsystem') =~ /Fedora/
+      host.execute('yum install -y bzip2')
+    end
+  end
+end
+
+RSpec.configure do |c|
+  module_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  c.formatter = :documentation
+
+  # Enable disabling of tests
+  c.filter_run_excluding :broken => true
+
+  c.before :suite do
+    # deploy hiera
+    hosts.each do |host|
+      on host, "/bin/touch #{default['puppetpath']}/hiera.yaml"
+      on host, "/bin/mkdir -p #{default['puppetpath']}/hieradata/"
+    end
+
+    # install modules from forge
+    forge_modules = [
+    ]
+    forge_modules.each do |m|
+      hosts.each do |host|
+        step "Installing puppet module \'#{m}\' on \'#{host}\'"
+        on host, puppet('module', 'install', m), :acceptable_exit_codes => [0, 1]
+      end
+    end
+
+    # install modules from git
+    # TODO: work out how to do branches and tags
+    git_repos = [
+      :mod => 'filemapper', :repo => 'https://github.com/voxpupuli/puppet-filemapper.git'
+    ]
+    git_repos.each do |g|
+      hosts.each do |host|
+        step "Installing puppet module \'#{g[:repo]}\' from git on \'#{host}\'"
+        on host, "rm -Rf #{default['puppetpath']}/modules/#{g[:mod]}"
+        on host, "git clone #{g[:repo]} #{default['puppetpath']}/modules/#{g[:mod]}", :acceptable_exit_codes => [0, 1]
+      end
+    end
+
+    # Install module
+    step "Installing this module and it's dependencies from \'#{module_root}\'"
+    puppet_module_install(:source => module_root, :module_name => 'network')
+  end
+end

--- a/spec/unit/provider/network_config/interfaces_spec.rb
+++ b/spec/unit/provider/network_config/interfaces_spec.rb
@@ -48,7 +48,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
                                                          :mode    => :raw,
                                                          :name    => 'eth0',
                                                          :hotplug => true,
-                                                         :options => {},)
+                                                         :options => {})
     end
 
     it 'should ignore source and source-directory lines' do
@@ -59,7 +59,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
                                                          :mode    => :raw,
                                                          :name    => 'eth0',
                                                          :hotplug => true,
-                                                         :options => {},)
+                                                         :options => {})
     end
 
     it 'should ignore variable whitespace in iface lines (network-#26)' do
@@ -70,7 +70,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
                                                          :mode    => :raw,
                                                          :name    => 'eth0',
                                                          :hotplug => true,
-                                                         :options => {},)
+                                                         :options => {})
     end
 
     it 'should parse out lines following iface lines' do
@@ -86,7 +86,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
                                                          :mtu       => '1500',
                                                          :options   => {
                                                            'broadcast' => '192.168.0.255',
-                                                           'gateway'   => '192.168.0.1',
+                                                           'gateway'   => '192.168.0.1'
                                                          })
     end
 
@@ -105,8 +105,8 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
                                                            'pre-up' => '/bin/touch /tmp/eth0-up',
                                                            'post-down' => [
                                                              '/bin/touch /tmp/eth0-down1',
-                                                             '/bin/touch /tmp/eth0-down2',
-                                                           ],
+                                                             '/bin/touch /tmp/eth0-down2'
+                                                           ]
                                                          })
     end
 
@@ -123,7 +123,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
                                                          :mtu       => '1500',
                                                          :options   => {
                                                            'broadcast' => '192.168.0.255',
-                                                           'gateway'   => '192.168.0.1',
+                                                           'gateway'   => '192.168.0.1'
                                                          })
       expect(data.find { |h| h[:name] == 'eth0.1' }).to eq(:name      => 'eth0.1',
                                                            :family    => 'inet',
@@ -135,7 +135,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
                                                            :mode      => :vlan,
                                                            :options   => {
                                                              'broadcast' => '172.16.0.255',
-                                                             'gateway'   => '172.16.0.1',
+                                                             'gateway'   => '172.16.0.1'
                                                            })
     end
 
@@ -203,8 +203,8 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
              'pre-up'    => '/bin/touch /tmp/eth1-up',
              'post-down' => [
                '/bin/touch /tmp/eth1-down1',
-               '/bin/touch /tmp/eth1-down2',
-             ],
+               '/bin/touch /tmp/eth1-down2'
+             ]
            }
       )
     end
@@ -278,7 +278,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
           'iface eth0 inet static',
           'address 169.254.0.1',
           'netmask 255.255.0.0',
-          'mtu 1500',
+          'mtu 1500'
         ].join("\n")
         expect(content.split('\n').find { |line| line.match(/iface eth0/) }).to match(block)
       end
@@ -305,7 +305,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
           'vlan-raw-device eth0',
           'address 169.254.0.1',
           'netmask 255.255.0.0',
-          'mtu 1500',
+          'mtu 1500'
         ].join("\n")
         expect(content.split('\n').find { |line| line.match(/iface eth0/) }).to match(block)
       end

--- a/spec/unit/provider/network_config/redhat_spec.rb
+++ b/spec/unit/provider/network_config/redhat_spec.rb
@@ -89,8 +89,8 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
 
     describe 'the options property' do
       let(:data) { described_class.parse_file('eth0', fixture_data('eth0-static'))[0] }
-      it { expect(data[:options]['USERCTL']).to eq('no') }
-      it { expect(data[:options]['NM_CONTROLLED']).to eq('no') }
+      it { expect(data[:options]['userctl']).to eq('no') }
+      it { expect(data[:options]['nm_controlled']).to eq('no') }
     end
 
     describe 'with no extra options' do
@@ -114,7 +114,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mtu) { should == '1500' }
         its(:options) do
           should == {
-            'BONDING_OPTS' => %(mode=4 miimon=100 xmit_hash_policy=layer3+4)
+            'bonding_opts' => %(mode=4 miimon=100 xmit_hash_policy=layer3+4)
           }
         end
       end
@@ -127,7 +127,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mtu) { should == '1500' }
         its(:options) do
           should == {
-            'BONDING_OPTS' => %(mode=4 miimon=100 xmit_hash_policy=layer3+4)
+            'bonding_opts' => %(mode=4 miimon=100 xmit_hash_policy=layer3+4)
           }
         end
       end
@@ -139,9 +139,9 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mode) { should == :raw }
         its(:options) do
           should == {
-            'HWADDR' => '00:12:79:91:28:1f',
-            'SLAVE'  => 'yes',
-            'MASTER' => 'bond0',
+            'hwaddr' => '00:12:79:91:28:1f',
+            'slave'  => 'yes',
+            'master' => 'bond0'
           }
         end
       end
@@ -153,9 +153,9 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mode) { should == :raw }
         its(:options) do
           should == {
-            'HWADDR' => '00:12:79:91:28:20',
-            'SLAVE'  => 'yes',
-            'MASTER' => 'bond0',
+            'hwaddr' => '00:12:79:91:28:20',
+            'slave'  => 'yes',
+            'master' => 'bond0'
           }
         end
       end
@@ -167,9 +167,9 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mode) { should == :raw }
         its(:options) do
           should == {
-            'HWADDR' => '00:26:55:e9:33:c4',
-            'SLAVE'  => 'yes',
-            'MASTER' => 'bond1',
+            'hwaddr' => '00:26:55:e9:33:c4',
+            'slave'  => 'yes',
+            'master' => 'bond1'
           }
         end
       end
@@ -181,9 +181,9 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mode) { should == :raw }
         its(:options) do
           should == {
-            'HWADDR' => '00:26:55:e9:33:c5',
-            'SLAVE'  => 'yes',
-            'MASTER' => 'bond1',
+            'hwaddr' => '00:26:55:e9:33:c5',
+            'slave'  => 'yes',
+            'master' => 'bond1'
           }
         end
       end
@@ -197,9 +197,9 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mode)      { should == :vlan }
         its(:options)   do
           should == {
-            'VLAN_NAME_TYPE' => 'VLAN_PLUS_VID_NO_PAD',
-            'PHYSDEV'        => 'bond0',
-            'GATEWAY'        => '172.24.61.1',
+            'vlan_name_type' => 'VLAN_PLUS_VID_NO_PAD',
+            'physdev'        => 'bond0',
+            'gateway'        => '172.24.61.1'
           }
         end
       end
@@ -222,8 +222,8 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mode)      { should == :vlan }
         its(:options)   do
           should == {
-            'VLAN_NAME_TYPE' => 'VLAN_PLUS_VID_NO_PAD',
-            'PHYSDEV'        => 'bond0',
+            'vlan_name_type' => 'VLAN_PLUS_VID_NO_PAD',
+            'physdev'        => 'bond0'
           }
         end
       end
@@ -237,8 +237,8 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mode)      { should == :vlan }
         its(:options)   do
           should == {
-            'VLAN_NAME_TYPE' => 'VLAN_PLUS_VID_NO_PAD',
-            'PHYSDEV'        => 'bond0',
+            'vlan_name_type' => 'VLAN_PLUS_VID_NO_PAD',
+            'physdev'        => 'bond0'
           }
         end
       end
@@ -252,8 +252,8 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mode)      { should == :vlan }
         its(:options)   do
           should == {
-            'VLAN_NAME_TYPE' => 'VLAN_PLUS_VID_NO_PAD',
-            'PHYSDEV'        => 'bond0',
+            'vlan_name_type' => 'VLAN_PLUS_VID_NO_PAD',
+            'physdev'        => 'bond0'
           }
         end
       end
@@ -267,8 +267,8 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mode)      { should == :vlan }
         its(:options)   do
           should == {
-            'VLAN_NAME_TYPE' => 'VLAN_PLUS_VID_NO_PAD',
-            'PHYSDEV'        => 'bond0',
+            'vlan_name_type' => 'VLAN_PLUS_VID_NO_PAD',
+            'physdev'        => 'bond0'
           }
         end
       end
@@ -290,10 +290,10 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mode)    { should == :vlan }
         its(:options) do
           should == {
-            'IPV6INIT'      => 'no',
-            'NM_CONTROLLED' => 'no',
-            'TYPE'          => 'Ethernet',
-            'BRIDGE'        => 'br1',
+            'ipv6init'      => 'no',
+            'nm_controlled' => 'no',
+            'type'          => 'Ethernet',
+            'bridge'        => 'br1'
           }
         end
       end
@@ -306,10 +306,10 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mode)    { should == :vlan }
         its(:options) do
           should == {
-            'IPV6INIT'      => 'no',
-            'NM_CONTROLLED' => 'no',
-            'TYPE'          => 'Ethernet',
-            'BRIDGE'        => 'br1',
+            'ipv6init'      => 'no',
+            'nm_controlled' => 'no',
+            'type'          => 'Ethernet',
+            'bridge'        => 'br1'
           }
         end
       end
@@ -322,10 +322,10 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:mode)    { should == :vlan }
         its(:options) do
           should == {
-            'IPV6INIT'      => 'no',
-            'NM_CONTROLLED' => 'no',
-            'TYPE'          => 'Ethernet',
-            'BRIDGE'        => 'br4095',
+            'ipv6init'      => 'no',
+            'nm_controlled' => 'no',
+            'type'          => 'Ethernet',
+            'bridge'        => 'br4095'
           }
         end
       end
@@ -407,6 +407,20 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       )
     end
 
+    let(:eth2_provider) do
+      stub('eth2_provider',
+           :name      => 'eth2',
+           :ipaddress => nil,
+           :netmask   => nil,
+           :hotplug   => true,
+           :onboot    => true,
+           :mtu       => nil,
+           :method    => 'none',
+           :mode      => nil,
+           :options   => {}
+      )
+    end
+
     it 'should fail if multiple interfaces are flushed to one file' do
       expect { described_class.format_file('filepath', [eth0_provider, lo_provider]) }.to raise_error Puppet::DevError, /multiple interfaces/
     end
@@ -443,6 +457,15 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       let(:data) { described_class.format_file('filepath', [bond0_provider]) }
 
       it { expect(data).to match(/BONDING_OPTS="mode=4 miimon=100 xmit_hash_policy=layer3\+4"/) }
+    end
+
+    describe 'with test interface eth2' do
+      let(:data) { described_class.format_file('filepath', [eth2_provider]) }
+
+      it { expect(data).to match(/DEVICE=eth2/) }
+      it { expect(data).to_not match(/IPADDR=/) }
+      it { expect(data).to_not match(/MTU=/) }
+      it { expect(data).to_not match(/NETMASK=/) }
     end
   end
 

--- a/spec/unit/provider/network_route/redhat_spec.rb
+++ b/spec/unit/provider/network_route/redhat_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Type.type(:network_route).provider(:redhat) do
                                                                      :network    => '172.17.67.0',
                                                                      :netmask    => '255.255.255.252',
                                                                      :gateway    => '172.18.6.2',
-                                                                     :interface  => 'vlan200',)
+                                                                     :interface  => 'vlan200')
       end
 
       it 'should parse out default routes' do
@@ -25,7 +25,7 @@ describe Puppet::Type.type(:network_route).provider(:redhat) do
                                                               :network    => 'default',
                                                               :netmask    => '0.0.0.0',
                                                               :gateway    => '10.0.0.1',
-                                                              :interface  => 'eth1',)
+                                                              :interface  => 'eth1')
       end
     end
 
@@ -38,7 +38,7 @@ describe Puppet::Type.type(:network_route).provider(:redhat) do
                                                                      :netmask    => '255.255.255.252',
                                                                      :gateway    => '172.18.6.2',
                                                                      :interface  => 'vlan200',
-                                                                     :options    => 'table 200',)
+                                                                     :options    => 'table 200')
       end
     end
 

--- a/spec/unit/provider/network_route/routes_spec.rb
+++ b/spec/unit/provider/network_route/routes_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Type.type(:network_route).provider(:routes) do
                                                                    :network    => '172.17.67.0',
                                                                    :netmask    => '255.255.255.0',
                                                                    :gateway    => '172.18.6.2',
-                                                                   :interface  => 'vlan200',)
+                                                                   :interface  => 'vlan200')
     end
 
     it 'should parse out advanced routes' do
@@ -29,7 +29,7 @@ describe Puppet::Type.type(:network_route).provider(:routes) do
                                                                    :netmask    => '255.255.255.0',
                                                                    :gateway    => '172.18.6.2',
                                                                    :interface  => 'vlan200',
-                                                                   :options    => 'table 200',)
+                                                                   :options    => 'table 200')
     end
 
     describe 'when reading an invalid routes file' do


### PR DESCRIPTION
- now compatible with Ruby 1.8.7 (CentOS 6)
- added debugging to make it easier to see what the redhat provider is doing
- munge() and unmunge() functions convert uppercase keys to lowercase property names
- properties that are 'absent' are not written to disk
- spec tests modified to reflect lowercase property names
- acceptance tests for CentOS 6 added

There is a slight breaking change in this code - the provider will now read key-value pairs into the options property as lower case. This doesn't affect writing resources, you can still have uppercase extra options and it will work as normal. You only see the difference if you run "puppet resource network_config" - it will now show the options hash keys as lower case.