### PR TITLE
Guard against :absent provider.options in redhat (issue 115)

### DIFF
--- a/lib/puppet/provider/network_config/redhat.rb
+++ b/lib/puppet/provider/network_config/redhat.rb
@@ -180,9 +180,9 @@ Puppet::Type.type(:network_config).provide(:redhat) do
     provider = providers[0]
     props    = {}
 
-    # Map everything to a flat hash
-    props = (provider.options || {})
+    props = provider.options if provider.options && provider.options != :absent
 
+    # Map everything to a flat hash
     NAME_MAPPINGS.keys.each do |type_name|
       if (val = provider.send(type_name))
         props[type_name] = val


### PR DESCRIPTION
Sometimes ```provider.options``` ends up with the value of ```:absent```, causing
a failure. The debian provider (interfaces.rb) already guards against
trying to manipulate ```:absent``` as a hash. Make the redhat provider also
guard against this. This should fix issue 115.

