### PR TITLE
Update metadata.json, CHANGELOG for the 0.5.0 release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,11 +35,20 @@ CHANGELOG
   * generate Debian auto/allow-hotplug only if not empty
   * (#104) fix a typo in the redhat provider for network_route
   * (#116) fix a vlan matching bug
+  * allow an empty hash for options
+  * ignore new Debian Jessie's features
+  * (#115) guard againt :absent provider.options in redhat
+  * (#143) make :absent attributes not get written to redhat files
+  * fix network facts on gentoo
 
 Thanks for their contributions to this release go to:
 
   * Adrien Thebo
   * Ahmed Elsabbahy
+  * Daniele Sluijters
+  * David Schmitt
+  * Davide Ferrari
+  * Derek Higgins
   * Drew Blessing
   * Eric Sakowski
   * Ewoud Kohl van Wijngaarden
@@ -49,12 +58,15 @@ Thanks for their contributions to this release go to:
   * Jasper Lievisse Adriaanse
   * Jon Skarpeteig
   * Jordi Clariana
+  * Joseph Yaworski
   * Joshua Hoblitt
   * Julian
   * Nan Liu
   * Robin H. Johnson
+  * Romanos Skiadas
   * Spencer Krum
   * Stefano Zilli
+  * Steffen Zieger
   * Vlastimil Holer
   * Wolf Noble
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,47 +1,58 @@
 {
-  "name":    "puppet-network",
+  "name": "puppet-network",
   "version": "0.5.0",
-  "author":  "puppetcommunity",
+  "author": "voxpupuli",
   "license": "Apache-2.0",
   "summary": "Manage non-volatile network configuration",
-
-  "source":       "https://github.com/puppet-community/puppet-network",
-  "project_page": "https://forge.puppetlabs.com/puppet/network",
-  "issues_url":   "https://github.com/puppet-community/puppet-network/issues",
-
-  "tags": [ "network" ],
-
+  "source": "https://github.com/voxpupuli/puppet-network",
+  "project_page": "https://github.com/voxpupuli/puppet-network",
+  "issues_url": "https://github.com/voxpupuli/puppet-network/issues",
+  "tags": [
+    "network",
+    "voxpupuli"
+  ],
   "operatingsystem_support": [
     {
-      "operatingsystem":"RedHat",
-      "operatingsystemrelease":[
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
         "5",
         "6",
         "7"
       ]
     },
     {
-      "operatingsystem":"CentOS",
-      "operatingsystemrelease":[
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
         "5",
         "6",
         "7"
       ]
     },
     {
-      "operatingsystem":"Debian",
-      "operatingsystemrelease":[
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
         "6",
         "7",
         "8"
       ]
     }
   ],
-
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.3.0" },
-    { "name": "adrien/filemapper", "version_requirement": ">= 1.0.0" },
-    { "name": "adrien/boolean",    "version_requirement": ">= 1.0.0" },
-    { "name": "camptocamp/kmod",   "version_requirement": ">= 0.0.1" }
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 2.3.0"
+    },
+    {
+      "name": "adrien/filemapper",
+      "version_requirement": ">= 1.0.0"
+    },
+    {
+      "name": "adrien/boolean",
+      "version_requirement": ">= 1.0.0"
+    },
+    {
+      "name": "camptocamp/kmod",
+      "version_requirement": ">= 0.0.1"
+    }
   ]
 }


### PR DESCRIPTION
Also fix the formatting with blacksmith.

This should be the release pr if I'm not mistaken and once it is merged someone with permissions can run the release target and get puppet-network-0.5.0 out to the forge.