### PR TITLE
Update README to better reflect the current module state

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,6 +3,8 @@ puppet-network
 
 Manage non-volatile network and route configuration.
 
+[![Puppet Forge](http://img.shields.io/puppetforge/v/puppet/network.svg)](https://forge.puppetlabs.com/puppet/network)
+
 Travis Test status: [![Build Status](https://travis-ci.org/voxpupuli/puppet-network.svg?branch=master)](https://travis-ci.org/voxpupuli/puppet-network)
 
 Examples
@@ -10,61 +12,67 @@ Examples
 
 Interface configuration
 
-    network_config { 'eth0':
-      ensure  => 'present',
-      family  => 'inet',
-      method  => 'dhcp',
-      onboot  => 'true',
-      hotplug => 'true',
-      options => {'pre-up' => 'sleep 2'},
-    }
+```puppet
+network_config { 'eth0':
+  ensure  => 'present',
+  family  => 'inet',
+  method  => 'dhcp',
+  onboot  => 'true',
+  hotplug => 'true',
+  options => {'pre-up' => 'sleep 2'},
+}
 
-    network_config { 'lo':
-      ensure => 'present',
-      family => 'inet',
-      method => 'loopback',
-      onboot => 'true',
-    }
+network_config { 'lo':
+  ensure => 'present',
+  family => 'inet',
+  method => 'loopback',
+  onboot => 'true',
+}
 
-    network_config { 'eth1':
-      ensure    => 'present',
-      family    => 'inet',
-      ipaddress => '169.254.0.1',
-      method    => 'static',
-      netmask   => '255.255.0.0',
-      onboot    => 'true',
-    }
+network_config { 'eth1':
+  ensure    => 'present',
+  family    => 'inet',
+  ipaddress => '169.254.0.1',
+  method    => 'static',
+  netmask   => '255.255.0.0',
+  onboot    => 'true',
+}
+```
 
 Route configuration
 
   For Debian:
 
-    network_route { '172.17.67.0':
-      ensure    => 'present',
-      gateway   => '172.18.6.2',
-      interface => 'vlan200',
-      netmask   => '255.255.255.0',
-      options   => 'table 200',
-    }
+```puppet
+network_route { '172.17.67.0':
+  ensure    => 'present',
+  gateway   => '172.18.6.2',
+  interface => 'vlan200',
+  netmask   => '255.255.255.0',
+  options   => 'table 200',
+}
+```
 
   For RedHat Enterprise:
 
-    network_route { '172.17.67.0/24':
-      ensure    => 'present',
-      gateway   => '10.0.2.2',
-      interface => 'eth0',
-      netmask   => '255.255.255.0',
-      network   => '172.17.67.0'
-      options   => 'table 200',
-    }
-    network_route { 'default':
-      ensure    => 'present',
-      gateway   => '10.0.2.2',
-      interface => 'eth0',
-      netmask  	=> '0.0.0.0',
-      network   => 'default'
-    }
-  
+```puppet
+network_route { '172.17.67.0/24':
+  ensure    => 'present',
+  gateway   => '10.0.2.2',
+  interface => 'eth0',
+  netmask   => '255.255.255.0',
+  network   => '172.17.67.0',
+  options   => 'table 200',
+}
+network_route { 'default':
+  ensure    => 'present',
+  gateway   => '10.0.2.2',
+  interface => 'eth0',
+  netmask  	=> '0.0.0.0',
+  network   => 'default'
+}
+```
+
 Create resources on the fly with the `puppet resource` command:
 
     root@debian-6:~# puppet resource network_config eth1 ensure=present family=inet method=static ipaddress=169.254.0.1 netmask=255.255.0.0
@@ -91,10 +99,10 @@ Create resources on the fly with the `puppet resource` command:
 Dependencies
 ------------
 
-The debian interfaces provider requires the FileMapper mixin, available at https://github.com/adrienthebo/puppet-filemapper
+This module requires the FileMapper mixin, available at https://github.com/voxpupuli/puppet-filemapper
 The debian routes provider requires the package [ifupdown-extra](http://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=ifupdown-extra)
 
-The network_config type requires the Boolean mixin, available at https://github.com/adrienthebo/puppet-boolean It also requires the `ipaddress` gem which can be installed with:
+The network_config type requires the Boolean mixin, available at https://github.com/adrienthebo/puppet-boolean. It also requires the `ipaddress` gem which can be installed with:
 
     sudo gem install ipaddress --no-ri --no-rdoc
 
@@ -113,5 +121,5 @@ Or on puppet 2.7/3.x:
 Contact
 -------
 
-  * Source code: https://github.com/puppet-community/puppet-network
-  * Issue tracker: https://github.com/puppet-community/puppet-network/issues
+  * Source code: https://github.com/voxpupuli/puppet-network
+  * Issue tracker: https://github.com/voxpupuli/puppet-network/issues


### PR DESCRIPTION
Change all references to puppet-community to voxpupuli, add forge
badge, explain that the filemapper mixin is a universal requirement.
Also fix a missing comma in one of the examples.