### PR TITLE
soft fail on missing ipaddress gem

### DIFF
--- a/lib/puppet/type/network_config.rb
+++ b/lib/puppet/type/network_config.rb
@@ -1,5 +1,10 @@
 require 'puppet/property/boolean'
-require 'ipaddress'
+
+begin
+  require 'ipaddress'
+rescue LoadError
+  Puppet.warning("#{__FILE__}:#{__LINE__}: ipaddress gem was not found")
+end
 
 Puppet::Type.newtype(:network_config) do
   @doc = 'Manage non-volatile network configuration information'
@@ -26,17 +31,21 @@ Puppet::Type.newtype(:network_config) do
 
   newproperty(:ipaddress) do
     desc 'The IP address of the network interfaces'
-    validate do |value|
-      raise ArgumentError, "#{self.class} requires a valid ipaddress for the ipaddress property" unless IPAddress.valid? value
-      # provider.validate
+    if defined? IPAddress
+      validate do |value|
+        raise ArgumentError, "#{self.class} requires a valid ipaddress for the ipaddress property" unless IPAddress.valid? value
+        # provider.validate
+      end
     end
   end
 
   newproperty(:netmask) do
     desc 'The subnet mask to apply to the interface'
-    validate do |value|
-      raise ArgumentError, "#{self.class} requires a valid netmask for the netmask property" unless IPAddress.valid_ipv4_netmask? value
-      # provider.validate
+    if defined? IPAddress
+      validate do |value|
+        raise ArgumentError, "#{self.class} requires a valid netmask for the netmask property" unless IPAddress.valid_ipv4_netmask? value
+        # provider.validate
+      end
     end
   end
 


### PR DESCRIPTION
Starting with version 0.5 the `ipaddress` gem is required. I'm OK with this, but if the gem is missing the whole puppet run fails (which is a bad thing after all):

```
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Function Call, Could not autoload puppet/type/network_config: cannot load such file -- ipaddress at /etc/puppet/environments/development/modules/profile/manifests/os/network.pp:164:3 on node xxx.example.com
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

What this means is that it's not possible to install the required gem if the `network` module was already included (i.e. by the ENC). This makes it hard to use this module in an environment with massive automation and auto-deployed VMs.

The gem is only used to provide (better) validation, so my proposal is to not kill the puppet run if the gem is missing, but instead send a clear warning message:

```
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Warning: /var/lib/puppet/lib/puppet/type/network_config.rb:6: ipaddress gem was not found
Info: Caching catalog for xxx.example.com
Info: Applying configuration version '1461246353'
Notice: Finished catalog run in 2.77 seconds
```