### PR TITLE
[WIP] Add a `network` class which installs the packages and gems required by

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -102,14 +102,20 @@ Create resources on the fly with the `puppet resource` command:
 Dependencies
 ------------
 
-This module requires the FileMapper mixin, available at https://github.com/voxpupuli/puppet-filemapper
-The debian routes provider requires the package [ifupdown-extra](http://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=ifupdown-extra)
+This module requires the FileMapper mixin, available at https://github.com/voxpupuli/puppet-filemapper. The network_config type requires the Boolean mixin, available at https://github.com/adrienthebo/puppet-boolean.
 
-The network_config type requires the Boolean mixin, available at https://github.com/adrienthebo/puppet-boolean. It also requires the `ipaddress` gem which can be installed with:
+The debian routes provider requires the package [ifupdown-extra](http://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=ifupdown-extra). The `network_config` class requires the `ipaddress` gem, which needs to be installed on both the puppet master and the nodes.
+`ifupdown-extra` and `ipaddress` can be installed automatically using the `network` class. To use it, include it like so in your manifests:
+
+```puppet
+include '::network'
+```
+
+This class also provides fine-grained control over which packages to install and how to install them. The documentation for the parameters exposed can be found [here](https://github.com/voxpupuli/puppet-network/blob/master/manifests/init.pp).
+
+The `ipaddress` gem can also be installed manually with:
 
     sudo gem install ipaddress --no-ri --no-rdoc
-
-This gem needs to always be installed on the agent before a puppet agent run, otherwise a catalog error will occur.
 
 Note: you may also need to update your master's plugins (run on your puppet master):
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,83 @@
+# = Class: network
+#
+# Install the packages and gems required by the network_route and network_config resources
+#
+# == Parameters
+#
+# [*ifupdown_extra*]
+#
+# The name of the ifupdown-extra package
+#
+# Default: ifupdown-extra
+#
+# [*ifupdown_extra_provider*]
+#
+# The provider of the ifupdown-extra package
+#
+# Default: undef
+#
+# [*manage_ifupdown_extra*]
+#
+# Whether this class should manage the ifupdown-extra package
+#
+# Default: true
+#
+# [*ensure_ifupdown_extra*]
+#
+# What state the ifupdown-extra package should be in
+#
+# Default: present
+#
+# [*ipaddress*]
+#
+# The name of the ipaddress gems
+#
+# Default: ipaddress
+#
+# [*ipaddress_provider*]
+#
+# The provider of the ipaddress gem
+#
+# Default: gem
+#
+# [*manage_ipaddress*]
+#
+# Whether this class should manage the ipaddress gem
+#
+# Default: true
+#
+# [*ensure_ipaddress*]
+#
+# What state the ifupdown-extra package should be in
+#
+# Default: present
+#
+
+class network(
+  $ifupdown_extra          = 'ifupdown-extra',
+  $ifupdown_extra_provider = undef,
+  $manage_ifupdown_extra   = true,
+  $ensure_ifupdown_extra   = present,
+  $ipaddress               = 'ipaddress',
+  $ipaddress_provider      = 'gem',
+  $manage_ipaddress        = true,
+  $ensure_ipaddress        = present,
+) {
+
+  if $::osfamily == 'Debian' and $manage_ifupdown_extra {
+    package { $ifupdown_extra:
+      ensure   => $ensure_ifupdown_extra,
+      provider => $ifupdown_extra_provider,
+    }
+    Package[$ifupdown_extra] -> Network_route <| |>
+  }
+
+  if $manage_ipaddress {
+    package { $ipaddress:
+      ensure   => $ensure_ipaddress,
+      provider => $ipaddress_provider,
+    }
+    Package[$ipaddress] -> Network_config <| |>
+  }
+
+}


### PR DESCRIPTION
puppet network.

This is regarding issue https://github.com/voxpupuli/puppet-network/issues/45. There are some things that still need to be done (docs, tests etc) but I'd like some feedback on it.

What kind of irks me is that a warning is thrown per https://github.com/voxpupuli/puppet-network/pull/155. even if you include the class which will install ipaddress.