### PR TITLE
Remove with_env, and trust in PATH being correct

### DIFF
--- a/lib/facter/network.rb
+++ b/lib/facter/network.rb
@@ -8,13 +8,11 @@ Facter.add('network_nexthop_ip') do
   my_gw = nil
   confine kernel: :linux
   setcode do
-    Facter::Util::Resolution.with_env('PATH' => '/bin:/sbin:/usr/bin:/usr/sbin') do
-      gw_address = Facter::Util::Resolution.exec('ip route show 0/0')
-      # not all network configurations will have a nexthop.
-      # the ip tool expresses the presence of a nexthop with the word 'via'
-      if gw_address.include? ' via '
-        my_gw = gw_address.split(%r{\s+})[2].match(%r{^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$}).to_s
-      end
+    gw_address = Facter::Util::Resolution.exec('ip route show 0/0')
+    # not all network configurations will have a nexthop.
+    # the ip tool expresses the presence of a nexthop with the word 'via'
+    if gw_address.include? ' via '
+      my_gw = gw_address.split(%r{\s+})[2].match(%r{^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$}).to_s
     end
     my_gw
   end
@@ -25,21 +23,19 @@ end
 Facter.add('network_primary_interface') do
   confine kernel: :linux
   setcode do
-    Facter::Util::Resolution.with_env('PATH' => '/bin:/sbin:/usr/bin:/usr/sbin') do
-      gw_address = Facter::Util::Resolution.exec('ip route show 0/0')
-      # not all network configurations will have a nexthop.
-      # the ip tool expresses the presence of a nexthop with the word 'via'
-      if gw_address.include? ' via '
-        my_gw = gw_address.split(%r{\s+})[2].match(%r{^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$}).to_s
-        fun = Facter::Util::Resolution.exec("ip route get #{my_gw}").split("\n")[0]
-      # some network configurations simply have a link that all interactions are abstracted through
-      elsif gw_address.include? 'scope link'
-        # since we have no default route ip to determine where to send 'traffic not otherwise explicitly routed'
-        # lets just use 8.8.8.8 as far as a route goes.
-        fun = Facter::Util::Resolution.exec('ip route get 8.8.8.8').split("\n")[0]
-      end
-      fun.split(%r{dev\s+([^\s]*)\s+src\s+([^\s]*)})[1].to_s
+    gw_address = Facter::Util::Resolution.exec('ip route show 0/0')
+    # not all network configurations will have a nexthop.
+    # the ip tool expresses the presence of a nexthop with the word 'via'
+    if gw_address.include? ' via '
+      my_gw = gw_address.split(%r{\s+})[2].match(%r{^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$}).to_s
+      fun = Facter::Util::Resolution.exec("ip route get #{my_gw}").split("\n")[0]
+    # some network configurations simply have a link that all interactions are abstracted through
+    elsif gw_address.include? 'scope link'
+      # since we have no default route ip to determine where to send 'traffic not otherwise explicitly routed'
+      # lets just use 8.8.8.8 as far as a route goes.
+      fun = Facter::Util::Resolution.exec('ip route get 8.8.8.8').split("\n")[0]
     end
+    fun.split(%r{dev\s+([^\s]*)\s+src\s+([^\s]*)})[1].to_s
   end
 end
 
@@ -48,17 +44,15 @@ end
 Facter.add('network_primary_ip') do
   confine kernel: :linux
   setcode do
-    Facter::Util::Resolution.with_env('PATH' => '/bin:/sbin:/usr/bin:/usr/sbin') do
-      gw_address = Facter::Util::Resolution.exec('ip route show 0/0')
-      if gw_address.include? ' via '
-        my_gw = gw_address.split(%r{\s+})[2].match(%r{^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$}).to_s
-        fun = Facter::Util::Resolution.exec("ip route get #{my_gw}").split("\n")[0]
-      elsif gw_address.include? 'scope link'
-        # since we have no default route ip to determine where to send 'traffic not otherwise explicitly routed'
-        # lets just use 8.8.8.8 as far as a route goes and grab our IP from there.
-        fun = Facter::Util::Resolution.exec('ip route get 8.8.8.8').split("\n")[0]
-      end
-      fun.split(%r{dev\s+([^\s]*)\s+src\s+([^\s]*)})[2].to_s
+    gw_address = Facter::Util::Resolution.exec('ip route show 0/0')
+    if gw_address.include? ' via '
+      my_gw = gw_address.split(%r{\s+})[2].match(%r{^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$}).to_s
+      fun = Facter::Util::Resolution.exec("ip route get #{my_gw}").split("\n")[0]
+    elsif gw_address.include? 'scope link'
+      # since we have no default route ip to determine where to send 'traffic not otherwise explicitly routed'
+      # lets just use 8.8.8.8 as far as a route goes and grab our IP from there.
+      fun = Facter::Util::Resolution.exec('ip route get 8.8.8.8').split("\n")[0]
     end
+    fun.split(%r{dev\s+([^\s]*)\s+src\s+([^\s]*)})[2].to_s
   end
 end

--- a/spec/unit/facts/network_nexthop_ip_spec.rb
+++ b/spec/unit/facts/network_nexthop_ip_spec.rb
@@ -15,7 +15,7 @@ describe 'network_nexthop_ip' do
     end
   end
   context 'on an OpenVZ VM' do
-    before :each do
+    before do
       Facter.clear
       Facter.fact(:kernel).stubs(:value).returns('linux')
       Facter.fact(:virtual).stubs(:value).returns('openvz')

--- a/spec/unit/facts/network_primary_interface_spec.rb
+++ b/spec/unit/facts/network_primary_interface_spec.rb
@@ -18,7 +18,7 @@ describe 'network_primary_interface' do
     end
   end
   context 'on an OpenVZ VM' do
-    before :each do
+    before do
       Facter.clear
       Facter.fact(:kernel).stubs(:value).returns('linux')
       Facter.fact(:virtual).stubs(:value).returns('openvz')

--- a/spec/unit/facts/network_primary_ip_spec.rb
+++ b/spec/unit/facts/network_primary_ip_spec.rb
@@ -17,7 +17,7 @@ describe 'network_primary_ip' do
     end
   end
   context 'on an OpenVZ VM' do
-    before :each do
+    before do
       Facter.clear
       Facter.fact(:kernel).stubs(:value).returns('linux')
       Facter.fact(:virtual).stubs(:value).returns('openvz')

--- a/spec/unit/provider/network_config/interfaces_spec.rb
+++ b/spec/unit/provider/network_config/interfaces_spec.rb
@@ -110,7 +110,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
                                                          })
     end
 
-    it 'parses out vlan iface lines' do
+    it 'parses out vlan iface lines' do # rubocop:disable RSpec/MultipleExpectations
       fixture = fixture_data('two_interfaces_static_vlan')
       data = described_class.parse_file('', fixture)
       expect(data.find { |h| h[:name] == 'eth0' }).to eq(name: 'eth0',
@@ -372,7 +372,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
           expect(content.scan(%r{post-down .*$}).size).to eq(2)
         end
 
-        it 'writes the values in order' do
+        it 'writes the values in order' do # rubocop:disable RSpec/MultipleExpectations
           expect(content.scan(%r{^\s*post-down .*$})[0]).to eq('    post-down /bin/touch /tmp/eth1-down1')
           expect(content.scan(%r{^\s*post-down .*$})[1]).to eq('    post-down /bin/touch /tmp/eth1-down2')
         end

--- a/spec/unit/provider/network_config/interfaces_spec.rb
+++ b/spec/unit/provider/network_config/interfaces_spec.rb
@@ -8,7 +8,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
     File.read(File.join(basedir, file))
   end
 
-  after :each do
+  after do
     v_level = $VERBOSE
     $VERBOSE = nil
     Puppet::Type::Network_config::ProviderInterfaces::Instance.reset!

--- a/spec/unit/provider/network_config/redhat_spec.rb
+++ b/spec/unit/provider/network_config/redhat_spec.rb
@@ -25,9 +25,9 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
   end
 
   describe 'selecting files to parse' do
-    let(:network_scripts_path) { fixture_file('network-scripts') }
-
     subject { described_class.target_files(network_scripts_path).map { |file| File.basename(file) } }
+
+    let(:network_scripts_path) { fixture_file('network-scripts') }
 
     valid_files = %w(ifcfg-bond0 ifcfg-bond1 ifcfg-eth0 ifcfg-eth1 ifcfg-eth2
                      ifcfg-eth3 ifcfg-vlan100 ifcfg-vlan100:0 ifcfg-vlan200


### PR DESCRIPTION
Modern versions of Facter (v3) don't have .with_env().
In this first step of modernising our facts, we remove the .with_env()
block and simply trust that the PATH is correct and that we'll be able
to find ip(8).

In a next step, we should replace Facter::Util::Resolution with
Facter::Core::Execution. note that this will require reworking the spec
tests which rely on different sets of external facts that *do* use
Facter::Util::Resolution.