### PR TITLE
Support for MTU on bonds.

### DIFF
--- a/manifests/bond.pp
+++ b/manifests/bond.pp
@@ -32,6 +32,10 @@
 #
 # Whether to allow hotplug for the interface.
 #
+# [*mtu*]
+#
+# The Maximum Transmission Unit size to use for bond interface and all slaves.
+#
 # [*options*]
 #
 # Hash with custom interfaces options.
@@ -143,6 +147,7 @@ define network::bond(
   $onboot           = undef,
   $hotplug          = undef,
   $lacp_rate        = undef,
+  $mtu              = undef,
   $options          = undef,
   $slave_options    = undef,
 
@@ -173,6 +178,7 @@ define network::bond(
         family           => $family,
         onboot           => $onboot,
         hotplug          => $hotplug,
+        mtu              => $mtu,
         options          => $options,
         slave_options    => $slave_options,
 
@@ -198,6 +204,7 @@ define network::bond(
         method           => $method,
         onboot           => $onboot,
         hotplug          => $hotplug,
+        mtu              => $mtu,
         options          => $options,
         slave_options    => $slave_options,
 

--- a/manifests/bond/debian.pp
+++ b/manifests/bond/debian.pp
@@ -14,6 +14,7 @@ define network::bond::debian(
   $family           = undef,
   $onboot           = undef,
   $hotplug          = undef,
+  $mtu              = undef,
   $options          = undef,
   $slave_options    = undef,
 
@@ -39,7 +40,15 @@ define network::bond::debian(
     'bond-xmit-hash-policy' => $xmit_hash_policy,
   }
 
-  $opts = compact_hash(merge($raw, $options))
+  if $mtu {
+    # https://bugs.launchpad.net/ubuntu/+source/ifupdown/+bug/1224007
+    validate_integer([$mtu], 65536, 42)
+    $raw_post_up = { 'post-up' => "ip link set dev ${name} mtu ${mtu}", }
+  } else {
+    $raw_post_up = {}
+  }
+
+  $opts = compact_hash(merge($raw, $raw_post_up, $options))
 
   network_config { $name:
     ensure    => $ensure,

--- a/manifests/bond/redhat.pp
+++ b/manifests/bond/redhat.pp
@@ -15,6 +15,7 @@ define network::bond::redhat(
   $family           = undef,
   $onboot           = undef,
   $hotplug          = undef,
+  $mtu              = undef,
   $options          = undef,
   $slave_options    = undef,
 
@@ -41,6 +42,7 @@ define network::bond::redhat(
     family    => $family,
     onboot    => $onboot,
     hotplug   => $hotplug,
+    mtu       => $mtu,
     options   => $opts,
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.3.0"
+      "version_requirement": ">= 4.6.0"
     },
     {
       "name": "voxpupuli/filemapper",

--- a/spec/defines/bond/debian_spec.rb
+++ b/spec/defines/bond/debian_spec.rb
@@ -56,6 +56,7 @@ describe 'network::bond::debian', type: :define do
         'ipaddress'        => '10.20.2.1',
         'netmask'          => '255.255.255.192',
         'slaves'           => %w(eth0 eth1 eth2),
+        'mtu'              => '1550',
         'options'          => { 'bond-future-option' => 'yes' },
         'slave_options'    => { 'slave-future-option' => 'no' },
         'hotplug'          => 'false',
@@ -88,7 +89,8 @@ describe 'network::bond::debian', type: :define do
                                                     'bond-updelay'          => '100',
                                                     'bond-lacp-rate'        => 'fast',
                                                     'bond-xmit-hash-policy' => 'layer3+4',
-                                                    'bond-future-option'    => 'yes'
+                                                    'bond-future-option'    => 'yes',
+                                                    'post-up'               => 'ip link set dev bond0 mtu 1550'
                                                   })
     end
   end

--- a/spec/defines/bond/redhat_spec.rb
+++ b/spec/defines/bond/redhat_spec.rb
@@ -55,6 +55,7 @@ describe 'network::bond::redhat', type: :define do
         'ipaddress'        => '10.20.2.1',
         'netmask'          => '255.255.255.192',
         'slaves'           => %w(eth0 eth1 eth2),
+        'mtu'              => '1550',
         'options'          => { 'NM_CONTROLLED' => 'yes' },
         'slave_options'    => { 'NM_CONTROLLED' => 'no' },
         'hotplug'          => 'false',
@@ -87,6 +88,7 @@ describe 'network::bond::redhat', type: :define do
                                                   'ipaddress' => '10.20.2.1',
                                                   'netmask'   => '255.255.255.192',
                                                   'hotplug'   => false,
+                                                  'mtu'       => '1550',
                                                   'options'   => {
                                                     'BONDING_OPTS'  => 'mode=balance-rr miimon=50 downdelay=100 updelay=100 lacp_rate=fast xmit_hash_policy=layer3+4',
                                                     'NM_CONTROLLED' => 'yes'

--- a/spec/defines/bond_spec.rb
+++ b/spec/defines/bond_spec.rb
@@ -10,6 +10,7 @@ describe 'network::bond', type: :define do
       'ipaddress'        => '172.18.1.2',
       'netmask'          => '255.255.128.0',
       'slaves'           => %w(eth0 eth1),
+      'mtu'              => '1550',
       'options'          => { 'NM_CONTROLLED' => 'yes' },
       'slave_options'    => { 'NM_CONTROLLED' => 'no' },
 


### PR DESCRIPTION
Following changes allow to specify MTU on bond interface. MTUs on bond slaves are inherited from master bond, therefore these are not necessary to specify. Thanks.

<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

