### PR TITLE
Fix name of filemapper dependency.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,7 @@
       "version_requirement": ">= 4.6.0"
     },
     {
-      "name": "voxpupuli/filemapper",
+      "name": "puppet/filemapper",
       "version_requirement": ">= 1.0.0"
     },
     {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

voxpupuli/filemapper doesn't exist on the puppet forge, it's called puppet/filemapper