### PR TITLE
Use Facter 3 if available for some facts

### DIFF
--- a/lib/facter/network.rb
+++ b/lib/facter/network.rb
@@ -2,6 +2,14 @@ require 'facter'
 require 'open-uri'
 require 'timeout'
 
+# Facter 3 has new facts that we can use instead of trying to do it
+# ourselves
+def facter_3
+  facter_version = Gem::Version.new(Facter.version)
+  version3 = Gem::Version.new('3.0.0')
+  facter_version >= version3
+end
+
 # Gateway
 # Expected output: The ip address of the nexthop/default router
 Facter.add('network_nexthop_ip') do
@@ -23,6 +31,7 @@ end
 Facter.add('network_primary_interface') do
   confine :kernel => :linux # rubocop:disable Style/HashSyntax
   setcode do
+    next Facter.fact(:networking).value['primary'] if facter_3
     gw_address = Facter::Util::Resolution.exec('ip route show 0/0')
     # not all network configurations will have a nexthop.
     # the ip tool expresses the presence of a nexthop with the word 'via'
@@ -40,10 +49,11 @@ Facter.add('network_primary_interface') do
 end
 
 # Primary IP
-#  Expected output: The ipaddress configred on the interface that communicates with the nexthop
+#  Expected output: The ipaddress configured on the interface that communicates with the nexthop
 Facter.add('network_primary_ip') do
   confine :kernel => :linux # rubocop:disable Style/HashSyntax
   setcode do
+    next Facter.fact(:networking).value['ip'] if facter_3
     gw_address = Facter::Util::Resolution.exec('ip route show 0/0')
     if gw_address.include? ' via '
       my_gw = gw_address.split(%r{\s+})[2].match(%r{^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$}).to_s

--- a/spec/unit/facts/network_primary_interface_spec.rb
+++ b/spec/unit/facts/network_primary_interface_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 describe 'network_primary_interface' do
   before do
+    Facter.clear
     Facter.fact(:kernel).stubs(:value).returns('linux')
-    Facter::Util::Resolution.stubs(:exec).with('ip route show 0/0').returns('default via 1.2.3.4 dev eth0')
   end
-  context 'on a Linux host' do
+  context 'on a Linux host with Facter 2.x' do
     before do
       Facter::Util::Resolution.stubs(:exec).with('ip route show 0/0').returns('default via 1.2.3.4 dev eth0')
       Facter::Util::Resolution.stubs(:exec).with('ip route get 1.2.3.4').returns('1.2.3.4 dev eth0  src 1.2.3.99\n
@@ -17,9 +17,9 @@ describe 'network_primary_interface' do
       expect(Facter.fact(:network_primary_interface).value).to eq('eth0')
     end
   end
-  context 'on an OpenVZ VM' do
+  context 'on an OpenVZ VM with Facter 2.x' do
     before do
-      Facter.clear
+      Facter.stubs(:version).returns('2.4.6')
       Facter.fact(:kernel).stubs(:value).returns('linux')
       Facter.fact(:virtual).stubs(:value).returns('openvz')
       Facter::Util::Resolution.stubs(:exec)
@@ -33,6 +33,21 @@ describe 'network_primary_interface' do
       it 'execs ip and determines the primary interface' do
         expect(Facter.fact(:network_primary_interface).value).to eq('venet0')
       end
+    end
+  end
+  context 'on a Linux host with Facter 3' do
+    before do
+      Facter::Util::Resolution.expects(:exec).never
+      interface_fact = Facter.fact(:network_primary_interface)
+      networking_fact = Facter::Util::Fact.new(:networking)
+      networking_fact.expects(:value).returns('primary' => 'eth1')
+      Facter.expects(:fact).with(:networking).returns(networking_fact)
+      Facter.expects(:fact).with(:network_primary_interface).returns(interface_fact)
+    end
+    it 'uses the built-in facts to determine the primary interface' do
+      # (rski) For some reason with ruby 1.9.3 this doesn't work in the before block
+      Facter.stubs(:version).returns('3.0.0')
+      expect(Facter.fact(:network_primary_interface).value).to eq('eth1')
     end
   end
 end

--- a/spec/unit/facts/network_primary_ip_spec.rb
+++ b/spec/unit/facts/network_primary_ip_spec.rb
@@ -4,22 +4,24 @@ require 'spec_helper'
 
 describe 'network_primary_ip' do
   before do
+    Facter.clear
     Facter.fact(:kernel).stubs(:value).returns('linux')
   end
-  context 'on a Linux host' do
+  context 'on a Linux host with Facter 2.x' do
     before do
-      Facter::Util::Resolution.stubs(:exec).with('ip route show 0/0').returns('default via 1.2.3.4 dev eth0')
+      Facter.stubs(:version).returns('2.4.6')
+      Facter::Util::Resolution.stubs(:exec).with('ip route show 0/0').returns('default via 1.2.3.4 dev eth0').once
       Facter::Util::Resolution.stubs(:exec).with('ip route get 1.2.3.4').returns("1.2.3.4 dev eth0  src 1.2.3.99\n
-  cache  mtu 1500 advmss 1460 hoplimit 64")
+  cache  mtu 1500 advmss 1460 hoplimit 64").once
     end
     it 'execs ip and determine the primary ip address' do
       expect(Facter.fact(:network_primary_ip).value).to eq('1.2.3.99')
     end
   end
-  context 'on an OpenVZ VM' do
+  context 'on an OpenVZ VM with Facter 2.x' do
     before do
       Facter.clear
-      Facter.fact(:kernel).stubs(:value).returns('linux')
+      Facter.stubs(:version).returns('2.4.6')
       Facter.fact(:virtual).stubs(:value).returns('openvz')
       Facter::Util::Resolution.stubs(:exec)
     end
@@ -29,9 +31,24 @@ describe 'network_primary_ip' do
         Facter::Util::Resolution.stubs(:exec).with('ip route get 8.8.8.8').returns("8.8.8.8 dev venet0  src 1.2.3.99\n
   cache  mtu 1500 advmss 1460 hoplimit 64")
       end
-      it 'execs ip and determine the primary interface' do
+      it 'execs ip and determine the primary ip address' do
         expect(Facter.fact(:network_primary_ip).value).to eq('1.2.3.99')
       end
+    end
+  end
+  context 'on a Linux host with Facter 3.x' do
+    before do
+      Facter::Util::Resolution.expects(:exec).never
+      ip_fact = Facter.fact(:network_primary_ip)
+      networking_fact = Facter::Util::Fact.new(:networking)
+      networking_fact.expects(:value).returns('ip' => '2.3.4.5')
+      Facter.expects(:fact).with(:networking).returns(networking_fact)
+      Facter.expects(:fact).with(:network_primary_ip).returns(ip_fact)
+    end
+    it 'uses the built-in facts to resolve the primary ip address' do
+      # (rski) For some reason this doesn't work with ruby 1.9.3
+      Facter.stubs(:version).returns('3.0.0')
+      expect(Facter.fact(:network_primary_ip).value).to eq('2.3.4.5')
     end
   end
 end


### PR DESCRIPTION
Primary interface and primary IP can be found from Facter 3 facts, so use those
if Facter 3 is available.