### PR TITLE
Fixed route creation for redhat/centos

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ network_route { '172.17.67.0/24':
   ensure    => 'present',
   gateway   => '10.0.2.2',
   interface => 'eth0',
-  netmask   => '255.255.255.0',
+  netmask   => '24',
   network   => '172.17.67.0',
   options   => 'table 200',
 }
@@ -75,7 +75,6 @@ network_route { 'default':
   ensure    => 'present',
   gateway   => '10.0.2.2',
   interface => 'eth0',
-  netmask   => '0.0.0.0',
   network   => 'default'
 }
 ```

--- a/lib/puppet/provider/network_route/redhat.rb
+++ b/lib/puppet/provider/network_route/redhat.rb
@@ -55,7 +55,6 @@ Puppet::Type.type(:network_route).provide(:redhat) do
 
         new_route[:name]    = cidr_target
         new_route[:network] = 'default'
-        new_route[:netmask] = '0.0.0.0'
       else
         # use the CIDR version of the target as :name
         network, netmask = route[0].split('/')

--- a/lib/puppet/provider/network_route/redhat.rb
+++ b/lib/puppet/provider/network_route/redhat.rb
@@ -55,6 +55,7 @@ Puppet::Type.type(:network_route).provide(:redhat) do
 
         new_route[:name]    = cidr_target
         new_route[:network] = 'default'
+        new_route[:netmask] = '0.0.0.0'
       else
         # use the CIDR version of the target as :name
         network, netmask = route[0].split('/')

--- a/lib/puppet/type/network_route.rb
+++ b/lib/puppet/type/network_route.rb
@@ -26,25 +26,10 @@ Puppet::Type.newtype(:network_route) do
 
   newproperty(:netmask) do
     isrequired
-    desc 'The subnet mask to apply to the route'
+    desc 'The subnet mask (in cidr style) to apply to the route'
 
     validate do |value|
-      unless value.length <= 3 || PuppetX::Voxpupuli::Utils.try { IPAddr.new(value) }
-        raise("Invalid value for argument netmask: #{value}")
-      end
-    end
-
-    munge do |value|
-      # '255.255.255.255'.to_i  will return 255, so we try to convert it back:
-      if value.to_i.to_s == value
-        # what are the chances someone is using /16 for their IPv6 network?
-        addr = value.to_i <= 32 ? '255.255.255.255' : 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff'
-        IPAddr.new(addr).mask(value.strip.to_i).to_s
-      elsif PuppetX::Voxpupuli::Utils.try { IPAddr.new(value).ipv6? }
-        IPAddr.new('ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff').mask(value).to_s
-      elsif PuppetX::Voxpupuli::Utils.try { IPAddr.new(value).ipv4? }
-        IPAddr.new('255.255.255.255').mask(value).to_s
-      else
+      unless value.length < 3 || PuppetX::Voxpupuli::Utils.try { IPAddr.new('255.255.255.255/' + value.to_s) }
         raise("Invalid value for argument netmask: #{value}")
       end
     end


### PR DESCRIPTION
https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/s1-networkscripts-static-routes.html cidr is now used instead of IPv4 network mask.

Was tested on a centos7 lxc container.

Todo:
- Clean up travis checks