### PR TITLE
Set min version_requirement for Puppet + bump deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Note: you may also need to update your master's plugins (run on your puppet mast
 
     puppet agent -t --noop
 
-Or on puppet 2.7/3.x:
+Or on puppet 3.8.7/4.x:
 
     puppet plugin download
 

--- a/metadata.json
+++ b/metadata.json
@@ -40,19 +40,25 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "puppet/filemapper",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 2.0.1 < 3.0.0"
     },
     {
-      "name": "adrien/boolean",
-      "version_requirement": ">= 1.0.0"
+      "name": "puppet/boolean",
+      "version_requirement": ">= 1.0.1 < 2.0.0"
     },
     {
       "name": "camptocamp/kmod",
-      "version_requirement": ">= 0.0.1"
+      "version_requirement": ">= 2.0.6 < 3.0.0"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">=3.8.7 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata

Also fix boolean module namespacing