### PR TITLE
update gem provider for 4.x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,7 +59,7 @@ class network(
   $manage_ifupdown_extra   = true,
   $ensure_ifupdown_extra   = present,
   $ipaddress               = 'ipaddress',
-  $ipaddress_provider      = 'gem',
+  $ipaddress_provider      = 'puppet_gem',
   $manage_ipaddress        = true,
   $ensure_ipaddress        = present,
 ) {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

On Puppet 4.x, the gem provider is `puppet_gem`.
This way puppet knows to look for the `gem` binary in the correct path.
Since we've dropped 3.x support, we have to update this assumption.