### PR TITLE
Allow Type network_config to take a Numeric value for the MTU parameter

### DIFF
--- a/lib/puppet/type/network_config.rb
+++ b/lib/puppet/type/network_config.rb
@@ -87,8 +87,14 @@ Puppet::Type.newtype(:network_config) do
     validate do |value|
       # reject floating point and negative integers
       # XXX this lets 1500.0 pass
-      unless value =~ %r{^\d+$}
-        raise ArgumentError, "#{value} is not a valid mtu (must be a positive integer)"
+      if value.is_a? Numeric
+        unless value.integer?
+          raise ArgumentError, "#{value} is not a valid mtu (must be a positive integer)"
+        end
+      else
+        unless value =~ %r{^\d+$}
+          raise ArgumentError, "#{value} is not a valid mtu (must be a positive integer)"
+        end
       end
 
       # Intel 82598 & 82599 chips support MTUs up to 16110; is there any

--- a/spec/unit/type/network_config_spec.rb
+++ b/spec/unit/type/network_config_spec.rb
@@ -146,12 +146,24 @@ describe Puppet::Type.type(:network_config) do
         Puppet::Type.type(:network_config).new(name: 'yay', mtu: '42')
       end
 
+      it 'validates a tiny mtu size as a number' do
+        Puppet::Type.type(:network_config).new(name: 'yay', mtu: 42)
+      end
+
       it 'validates a normal mtu size' do
         Puppet::Type.type(:network_config).new(name: 'yay', mtu: '1500')
       end
 
+      it 'validates a normal mtu size as a number' do
+        Puppet::Type.type(:network_config).new(name: 'yay', mtu: 1500)
+      end
+
       it 'validates a large mtu size' do
         Puppet::Type.type(:network_config).new(name: 'yay', mtu: '16384')
+      end
+
+      it 'validates a large mtu size as a number' do
+        Puppet::Type.type(:network_config).new(name: 'yay', mtu: 16_384)
       end
 
       it 'fails if an random string is passed' do
@@ -166,9 +178,21 @@ describe Puppet::Type.type(:network_config) do
         end.to raise_error
       end
 
+      it 'fails on numeric values < 42' do
+        expect do
+          Puppet::Type.type(:network_config).new(name: 'yay', mtu: 41)
+        end.to raise_error
+      end
+
       it 'fails on zero' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: '0')
+        end.to raise_error
+      end
+
+      it 'fails on numeric zero' do
+        expect do
+          Puppet::Type.type(:network_config).new(name: 'yay', mtu: 0)
         end.to raise_error
       end
 
@@ -178,15 +202,33 @@ describe Puppet::Type.type(:network_config) do
         end.to raise_error
       end
 
+      it 'fails on numeric values > 65536' do
+        expect do
+          Puppet::Type.type(:network_config).new(name: 'yay', mtu: 65_537)
+        end.to raise_error
+      end
+
       it 'fails on negative values' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: '-1500')
         end.to raise_error
       end
 
+      it 'fails on negative numbers' do
+        expect do
+          Puppet::Type.type(:network_config).new(name: 'yay', mtu: -1500)
+        end.to raise_error
+      end
+
       it 'fails on non-integer values' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: '1500.1')
+        end.to raise_error
+      end
+
+      it 'fails on numeric non-integer values' do
+        expect do
+          Puppet::Type.type(:network_config).new(name: 'yay', mtu: 1500.1)
         end.to raise_error
       end
     end


### PR DESCRIPTION
It's feasible to provide a Numeric type to the MTU parameter in Puppet 4 (such as the result of a calculation).  This patch allows the network_config Type to accept a Numeric as well as a String, and tests for all the same expected failure cases with numeric values.