### PR TITLE
Stop using $::osfamily but use $facts['osfamily']

### DIFF
--- a/manifests/bond.pp
+++ b/manifests/bond.pp
@@ -167,7 +167,7 @@ define network::bond(
     source => 'bonding',
   }
 
-  case $::osfamily {
+  case $facts['osfamily'] {
     'Debian': {
       network::bond::debian { $name:
         ensure           => $ensure,
@@ -221,7 +221,7 @@ define network::bond(
       }
     }
     default: {
-      fail("network::bond does not support osfamily '${::osfamily}'")
+      fail("network::bond does not support osfamily '${facts['osfamily']}'")
     }
   }
 }

--- a/manifests/bond/setup.pp
+++ b/manifests/bond/setup.pp
@@ -1,7 +1,7 @@
 # make it work on debian..
 class network::bond::setup {
 
-  case $::osfamily {
+  case $facts['osfamily'] {
     'Debian': {
       package { 'ifenslave-2.6':
         ensure => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,7 +64,7 @@ class network(
   $ensure_ipaddress        = present,
 ) {
 
-  if $::osfamily == 'Debian' and $manage_ifupdown_extra {
+  if $facts['osfamily'] == 'Debian' and $manage_ifupdown_extra {
     package { $ifupdown_extra:
       ensure   => $ensure_ifupdown_extra,
       provider => $ifupdown_extra_provider,

--- a/spec/defines/bond_spec.rb
+++ b/spec/defines/bond_spec.rb
@@ -64,7 +64,7 @@ describe 'network::bond', type: :define do
       let(:facts) { { osfamily: 'SparrowOS' } }
 
       it 'fails to compile' do
-        expect { is_expected.to compile }.to raise_error(%r{network::bond does not support osfamily 'SparrowOS'})
+        is_expected.to compile.and_raise_error(%r{network::bond does not support osfamily 'SparrowOS'})
       end
     end
   end


### PR DESCRIPTION
Also modernized the compile.and_raise_error test.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
