### PR TITLE
Get rid of all raise_error warnings in the tests and align errors a bit

### DIFF
--- a/lib/puppet/provider/network_route/redhat.rb
+++ b/lib/puppet/provider/network_route/redhat.rb
@@ -79,7 +79,7 @@ Puppet::Type.type(:network_route).provide(:redhat) do
     # Build routes
     providers.sort_by(&:name).each do |provider|
       [:network, :netmask, :gateway, :interface].each do |prop|
-        raise Puppet::Error, "#{provider.name} does not have a #{prop}." if provider.send(prop).nil?
+        raise Puppet::Error, "#{provider.name} is missing the required parameter '#{prop}'." if provider.send(prop).nil?
       end
       contents << if provider.network == 'default'
                     "#{provider.network} via #{provider.gateway} dev #{provider.interface}"

--- a/lib/puppet/type/network_config.rb
+++ b/lib/puppet/type/network_config.rb
@@ -137,7 +137,7 @@ Puppet::Type.newtype(:network_config) do
     defaultto {}
 
     validate do |value|
-      raise ArgumentError, "#{self.class} requires a hash for the options property" unless value.is_a? Hash
+      raise ArgumentError, "#{self.class} requires a hash for the 'options' parameter" unless value.is_a? Hash
       # provider.validate
     end
   end

--- a/lib/puppet/type/network_route.rb
+++ b/lib/puppet/type/network_route.rb
@@ -19,7 +19,7 @@ Puppet::Type.newtype(:network_route) do
     validate do |value|
       unless value == 'default'
         a = PuppetX::Voxpupuli::Utils.try { IPAddr.new(value) }
-        raise("Invalid value for network: #{value}") unless a
+        raise("Invalid value for parameter 'network': #{value}") unless a
       end
     end
   end
@@ -30,7 +30,7 @@ Puppet::Type.newtype(:network_route) do
 
     validate do |value|
       unless value.length <= 3 || PuppetX::Voxpupuli::Utils.try { IPAddr.new(value) }
-        raise("Invalid value for argument netmask: #{value}")
+        raise("Invalid value for parameter 'netmask': #{value}")
       end
     end
 
@@ -45,7 +45,7 @@ Puppet::Type.newtype(:network_route) do
       elsif PuppetX::Voxpupuli::Utils.try { IPAddr.new(value).ipv4? }
         IPAddr.new('255.255.255.255').mask(value).to_s
       else
-        raise("Invalid value for argument netmask: #{value}")
+        raise("Invalid value for parameter 'netmask': #{value}")
       end
     end
   end
@@ -58,7 +58,7 @@ Puppet::Type.newtype(:network_route) do
       begin
         IPAddr.new(value)
       rescue ArgumentError
-        raise("Invalid value for gateway: #{value}")
+        raise("Invalid value for parameter 'gateway': #{value}")
       end
     end
   end

--- a/spec/unit/provider/network_config/interfaces_spec.rb
+++ b/spec/unit/provider/network_config/interfaces_spec.rb
@@ -142,13 +142,13 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
       it 'with misplaced options should fail' do
         expect do
           described_class.parse_file('', "address 192.168.1.1\niface eth0 inet static\n")
-        end.to raise_error
+        end.to raise_error(%r{Malformed debian interfaces file})
       end
 
       it 'with an option without a value should fail' do
         expect do
           described_class.parse_file('', "iface eth0 inet manual\naddress")
-        end.to raise_error
+        end.to raise_error(%r{Malformed debian interfaces file})
       end
     end
   end
@@ -313,13 +313,13 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
       it 'fails if the family property is not defined' do
         lo_provider.unstub(:family)
         lo_provider.stubs(:family).returns nil
-        expect { content }.to raise_exception
+        expect { content }.to raise_exception(%r{does not have a family})
       end
 
       it 'fails if the method property is not defined' do
         lo_provider.unstub(:method)
         lo_provider.stubs(:method).returns nil
-        expect { content }.to raise_exception
+        expect { content }.to raise_exception(%r{does not have a method})
       end
     end
 

--- a/spec/unit/provider/network_route/redhat_spec.rb
+++ b/spec/unit/provider/network_route/redhat_spec.rb
@@ -72,7 +72,7 @@ describe Puppet::Type.type(:network_route).provider(:redhat) do
       it 'fails' do
         expect do
           described_class.parse_file('', "192.168.1.1/30 via\n")
-        end.to raise_error
+        end.to raise_error(%r{Malformed redhat route file})
       end
     end
   end
@@ -147,13 +147,13 @@ describe Puppet::Type.type(:network_route).provider(:redhat) do
         it 'fails if the netmask property is not defined' do
           route2_provider.unstub(:netmask)
           route2_provider.stubs(:netmask).returns nil
-          expect { content }.to raise_exception
+          expect { content }.to raise_exception(%r{is missing the required parameter 'netmask'})
         end
 
         it 'fails if the gateway property is not defined' do
           route2_provider.unstub(:gateway)
           route2_provider.stubs(:gateway).returns nil
-          expect { content }.to raise_exception
+          expect { content }.to raise_exception(%r{is missing the required parameter 'gateway'})
         end
       end
     end

--- a/spec/unit/provider/network_route/routes_spec.rb
+++ b/spec/unit/provider/network_route/routes_spec.rb
@@ -77,7 +77,7 @@ describe Puppet::Type.type(:network_route).provider(:routes) do
       it 'with missing options should fail' do
         expect do
           described_class.parse_file('', "192.168.1.1 255.255.255.0 172.16.0.1\n")
-        end.to raise_error
+        end.to raise_error(%r{Malformed debian routes file})
       end
     end
   end
@@ -126,13 +126,13 @@ describe Puppet::Type.type(:network_route).provider(:routes) do
       it 'fails if the netmask property is not defined' do
         route2_provider.unstub(:netmask)
         route2_provider.stubs(:netmask).returns nil
-        expect { content }.to raise_exception
+        expect { content }.to raise_exception(%r{is missing the required parameter 'netmask'})
       end
 
       it 'fails if the gateway property is not defined' do
         route2_provider.unstub(:gateway)
         route2_provider.stubs(:gateway).returns nil
-        expect { content }.to raise_exception
+        expect { content }.to raise_exception(%r{is missing the required parameter 'gateway'})
       end
     end
   end
@@ -181,13 +181,13 @@ describe Puppet::Type.type(:network_route).provider(:routes) do
       it 'fails if the netmask property is not defined' do
         route2_provider.unstub(:netmask)
         route2_provider.stubs(:netmask).returns nil
-        expect { content }.to raise_exception
+        expect { content }.to raise_exception(%r{is missing the required parameter 'netmask'})
       end
 
       it 'fails if the gateway property is not defined' do
         route2_provider.unstub(:gateway)
         route2_provider.stubs(:gateway).returns nil
-        expect { content }.to raise_exception
+        expect { content }.to raise_exception(%r{is missing the required parameter 'gateway'})
       end
     end
   end

--- a/spec/unit/type/network_config_spec.rb
+++ b/spec/unit/type/network_config_spec.rb
@@ -80,7 +80,7 @@ describe Puppet::Type.type(:network_config) do
         end
         it 'fails when passed an IPv6 address' do
           pending('Not yet implemented')
-          expect { Puppet::Type.type(:network_config).new(name: 'yay', family: :inet, ipaddress: address6) }.to raise_error
+          expect { Puppet::Type.type(:network_config).new(name: 'yay', family: :inet, ipaddress: address6) }.to raise_error(%r{not a valid ipv4 address})
         end
       end
 
@@ -90,12 +90,12 @@ describe Puppet::Type.type(:network_config) do
         end
         it 'fails when passed an IPv4 address' do
           pending('Not yet implemented')
-          expect { Puppet::Type.type(:network_config).new(name: 'yay', family: :inet6, ipaddress: address4) }.to raise_error
+          expect { Puppet::Type.type(:network_config).new(name: 'yay', family: :inet6, ipaddress: address4) }.to raise_error(%r{not a valid ipv6 address})
         end
       end
 
       it 'fails if a malformed address is used' do
-        expect { Puppet::Type.type(:network_config).new(name: 'yay', ipaddress: 'This is clearly not an IP address') }.to raise_error
+        expect { Puppet::Type.type(:network_config).new(name: 'yay', ipaddress: 'This is clearly not an IP address') }.to raise_error(%r{requires a valid ipaddress})
       end
     end
 
@@ -103,7 +103,7 @@ describe Puppet::Type.type(:network_config) do
       it 'fails if an invalid CIDR netmask is used' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', netmask: 'This is clearly not a netmask')
-        end.to raise_error
+        end.to raise_error(%r{requires a valid netmask})
       end
     end
 
@@ -167,67 +167,67 @@ describe Puppet::Type.type(:network_config) do
       it 'fails if an random string is passed' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: 'This is clearly not a mtu')
-        end.to raise_error
+        end.to raise_error(%r{must be a positive integer})
       end
 
       it 'fails on values < 42' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: '41')
-        end.to raise_error
+        end.to raise_error(%r{is not in the valid mtu range})
       end
 
       it 'fails on numeric values < 42' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: 41)
-        end.to raise_error
+        end.to raise_error(%r{is not in the valid mtu range})
       end
 
       it 'fails on zero' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: '0')
-        end.to raise_error
+        end.to raise_error(%r{is not in the valid mtu range})
       end
 
       it 'fails on numeric zero' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: 0)
-        end.to raise_error
+        end.to raise_error(%r{is not in the valid mtu range})
       end
 
       it 'fails on values > 65536' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: '65537')
-        end.to raise_error
+        end.to raise_error(%r{is not in the valid mtu range})
       end
 
       it 'fails on numeric values > 65536' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: 65_537)
-        end.to raise_error
+        end.to raise_error(%r{is not in the valid mtu range})
       end
 
       it 'fails on negative values' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: '-1500')
-        end.to raise_error
+        end.to raise_error(%r{is not a valid mtu})
       end
 
       it 'fails on negative numbers' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: -1500)
-        end.to raise_error
+        end.to raise_error(%r{is not in the valid mtu range})
       end
 
       it 'fails on non-integer values' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: '1500.1')
-        end.to raise_error
+        end.to raise_error(%r{must be a positive integer})
       end
 
       it 'fails on numeric non-integer values' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mtu: 1500.1)
-        end.to raise_error
+        end.to raise_error(%r{must be a positive integer})
       end
     end
 
@@ -240,7 +240,7 @@ describe Puppet::Type.type(:network_config) do
       it 'fails on undefined values' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'yay', mode: 'foo')
-        end.to raise_error
+        end.to raise_error(%r{Invalid value "foo". Valid values are})
       end
       it 'defaults to :raw' do
         expect(Puppet::Type.type(:network_config).new(name: 'yay')[:mode]).to eq(:raw)
@@ -262,7 +262,7 @@ describe Puppet::Type.type(:network_config) do
       it 'fails if a non-hash is passed' do
         expect do
           Puppet::Type.type(:network_config).new(name: 'valid', options: 'geese')
-        end.to raise_error
+        end.to raise_error(%r{requires a hash for the 'options' parameter})
       end
     end
   end

--- a/spec/unit/type/network_route_spec.rb
+++ b/spec/unit/type/network_route_spec.rb
@@ -36,7 +36,7 @@ describe Puppet::Type.type(:network_route) do
       it 'validates the network as an IP address' do
         expect do
           Puppet::Type.type(:network_route).new(name: '192.168.1.0/24', network: 'not an ip address', netmask: '255.255.255.0', gateway: '23.23.23.42', interface: 'eth0')
-        end.to raise_error
+        end.to raise_error(%r{Invalid value for parameter 'network'})
       end
     end
 
@@ -44,7 +44,7 @@ describe Puppet::Type.type(:network_route) do
       it 'fails if an invalid netmask is used' do
         expect do
           Puppet::Type.type(:network_route).new(name: '192.168.1.0/24', network: '192.168.1.0', netmask: 'This is clearly not a netmask', gateway: '23.23.23.42', interface: 'eth0')
-        end.to raise_error
+        end.to raise_error(%r{Invalid value for parameter 'netmask'})
       end
 
       it 'converts netmasks of the CIDR form' do
@@ -67,7 +67,7 @@ describe Puppet::Type.type(:network_route) do
       it 'validates as an IP address' do
         expect do
           Puppet::Type.type(:network_route).new(name: '192.168.1.0/24', network: '192.168.1.0', netmask: '255.255.255.0', gateway: 'not an ip address', interface: 'eth0')
-        end.to raise_error
+        end.to raise_error(%r{Invalid value for parameter 'gateway'})
       end
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
