### PR TITLE
Bump version requirements for stdlib/Puppet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.13.1 < 7.0.0"
     },
     {
       "name": "puppet/filemapper",
@@ -54,7 +54,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 6.0.0"
+      "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
Bump version requirements for stdlib and Puppet to support versions `< 7.0.0`. Tested in production and passes spec tests.

Fixes #250.