### PR TITLE
Use confine to ensure `ip` is available for network fact

### DIFF
--- a/lib/facter/network.rb
+++ b/lib/facter/network.rb
@@ -13,8 +13,10 @@ end
 # Gateway
 # Expected output: The ip address of the nexthop/default router
 Facter.add('network_nexthop_ip') do
-  my_gw = nil
   confine :kernel => :linux # rubocop:disable Style/HashSyntax
+  confine { Facter::Util::Resolution.which('ip') }
+
+  my_gw = nil
   setcode do
     gw_address = Facter::Util::Resolution.exec('ip route show 0/0')
     # not all network configurations will have a nexthop.
@@ -30,6 +32,8 @@ end
 #  Expected output: The specific interface name that the node uses to communicate with the nexthop
 Facter.add('network_primary_interface') do
   confine :kernel => :linux # rubocop:disable Style/HashSyntax
+  confine { Facter::Util::Resolution.which('ip') }
+
   setcode do
     next Facter.fact(:networking).value['primary'] if facter_3
     gw_address = Facter::Util::Resolution.exec('ip route show 0/0')
@@ -52,6 +56,8 @@ end
 #  Expected output: The ipaddress configured on the interface that communicates with the nexthop
 Facter.add('network_primary_ip') do
   confine :kernel => :linux # rubocop:disable Style/HashSyntax
+  confine { Facter::Util::Resolution.which('ip') }
+
   setcode do
     next Facter.fact(:networking).value['ip'] if facter_3
     gw_address = Facter::Util::Resolution.exec('ip route show 0/0')


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR adds confines to the facts `network_nexthop_ip` , `network_primary_interface` and `network_primary_ip` to avoid ugly errors when `ip` (from `iproute2`) is unavailable.

#### This Pull Request (PR) fixes the following issues
None