### PR TITLE
Switch to rspec for testing.

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,7 +2,7 @@
 .travis.yml:
   secure: "DjiIx0gDrAUU176TA+7WxrEJ27D504Irrhx37dqxmR/GXEMX58swwwsdr3wlaklR7/LAVafsL98A0Ff+DtynAOYcFXkmJHc3ZObp4UDHqKot2mzL8rrzf+23cO8eiKW72sNKarn4wzSlR9OXjbAf/m68u+SBkRm+cWUUZhSgFiY="
 spec/spec_helper.rb:
-  mock_with: ':mocha'
+  mock_with: ':rspec'
   spec_overrides: "require 'spec_helper_methods'"
 Gemfile:
   optional:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
 RSpec.configure do |c|
-  c.mock_with :mocha
+  c.mock_with :rspec
 end
 
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/spec/unit/facts/network_nexthop_ip_spec.rb
+++ b/spec/unit/facts/network_nexthop_ip_spec.rb
@@ -2,11 +2,12 @@ require 'spec_helper'
 
 describe 'network_nexthop_ip' do
   before do
-    Facter.fact(:kernel).stubs(:value).returns('linux')
+    Facter.clear
+    allow(Facter.fact(:kernel)).to receive(:value).and_return('linux')
   end
   context 'on a Linux host' do
     before do
-      Facter::Util::Resolution.stubs(:exec).with('ip route show 0/0').returns('default via 1.2.3.4 dev eth0')
+      allow(Facter::Util::Resolution).to receive(:exec).with('ip route show 0/0').and_return('default via 1.2.3.4 dev eth0')
     end
     it 'execs ip and determine the next hop' do
       expect(Facter.fact(:network_nexthop_ip).value).to eq('1.2.3.4')
@@ -15,14 +16,14 @@ describe 'network_nexthop_ip' do
   context 'on an OpenVZ VM' do
     before do
       Facter.clear
-      Facter.fact(:kernel).stubs(:value).returns('linux')
-      Facter.fact(:virtual).stubs(:value).returns('openvz')
-      Facter::Util::Resolution.stubs(:exec)
+      allow(Facter.fact(:kernel)).to receive(:value).and_return('linux')
+      allow(Facter.fact(:virtual)).to receive(:value).and_return('openvz')
+      allow(Facter::Util::Resolution).to receive(:exec)
     end
     context 'which has the default route via a veth device' do
       before do
-        Facter.fact(:macaddress).stubs(:value).returns(nil)
-        Facter::Util::Resolution.stubs(:exec).with('ip route show 0/0').returns('default via 1.2.3.4 dev eth0')
+        allow(Facter::Util::Resolution).to receive(:exec).with('ip route show 0/0').and_return('default via 1.2.3.4 dev eth0')
+        allow(Facter.fact(:macaddress)).to receive(:value).and_return(nil)
       end
       it 'execs ip and determine the next hop' do
         expect(Facter.fact(:network_nexthop_ip).value).to eq('1.2.3.4')
@@ -30,7 +31,7 @@ describe 'network_nexthop_ip' do
     end
     context 'with only venet interfaces' do
       before do
-        Facter::Util::Resolution.stubs(:exec).with('ip route show 0/0').returns('default dev venet0  scope link')
+        allow(Facter::Util::Resolution).to receive(:exec).with('ip route show 0/0').and_return('default dev venet0  scope link')
       end
       it 'does not exist' do
         expect(Facter.fact(:network_nexthop_ip).value).to be_nil

--- a/spec/unit/facts/network_primary_interface_spec.rb
+++ b/spec/unit/facts/network_primary_interface_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe 'network_primary_interface' do
   before do
     Facter.clear
-    Facter.fact(:kernel).stubs(:value).returns('linux')
+    allow(Facter.fact(:kernel)).to receive(:value).and_return('linux')
   end
   context 'on a Linux host with Facter 2.x' do
     before do
-      Facter::Util::Resolution.stubs(:exec).with('ip route show 0/0').returns('default via 1.2.3.4 dev eth0')
-      Facter::Util::Resolution.stubs(:exec).with('ip route get 1.2.3.4').returns('1.2.3.4 dev eth0  src 1.2.3.99\n
+      allow(Facter::Util::Resolution).to receive(:exec).with('ip route show 0/0').and_return('default via 1.2.3.4 dev eth0')
+      allow(Facter::Util::Resolution).to receive(:exec).with('ip route get 1.2.3.4').and_return('1.2.3.4 dev eth0  src 1.2.3.99\n
   cache  mtu 1500 advmss 1460 hoplimit 64')
     end
     it 'execs ip and determines the primary interface' do
@@ -17,15 +17,15 @@ describe 'network_primary_interface' do
   end
   context 'on an OpenVZ VM with Facter 2.x' do
     before do
-      Facter.stubs(:version).returns('2.4.6')
-      Facter.fact(:kernel).stubs(:value).returns('linux')
-      Facter.fact(:virtual).stubs(:value).returns('openvz')
-      Facter::Util::Resolution.stubs(:exec)
+      allow(Facter).to receive(:version).and_return('2.4.6')
+      allow(Facter.fact(:kernel)).to receive(:value).and_return('linux')
+      allow(Facter.fact(:virtual)).to receive(:value).and_return('openvz')
+      allow(Facter::Util::Resolution).to receive(:exec)
     end
     context 'with only venet devices' do
       before do
-        Facter::Util::Resolution.stubs(:exec).with('ip route show 0/0').returns('default dev venet0  scope link')
-        Facter::Util::Resolution.stubs(:exec).with('ip route get 8.8.8.8').returns('8.8.8.8 dev venet0  src 1.2.3.99\n
+        allow(Facter::Util::Resolution).to receive(:exec).with('ip route show 0/0').and_return('default dev venet0  scope link')
+        allow(Facter::Util::Resolution).to receive(:exec).with('ip route get 8.8.8.8').and_return('8.8.8.8 dev venet0  src 1.2.3.99\n
   cache  mtu 1500 advmss 1460 hoplimit 64')
       end
       it 'execs ip and determines the primary interface' do
@@ -35,16 +35,15 @@ describe 'network_primary_interface' do
   end
   context 'on a Linux host with Facter 3' do
     before do
-      Facter::Util::Resolution.expects(:exec).never
       interface_fact = Facter.fact(:network_primary_interface)
       networking_fact = Facter::Util::Fact.new(:networking)
-      networking_fact.expects(:value).returns('primary' => 'eth1')
-      Facter.expects(:fact).with(:networking).returns(networking_fact)
-      Facter.expects(:fact).with(:network_primary_interface).returns(interface_fact)
+      allow(networking_fact).to receive(:value).and_return('primary' => 'eth1')
+      allow(Facter).to receive(:fact).with(:network_primary_interface).and_return(interface_fact)
+      allow(Facter).to receive(:fact).with(:networking).and_return(networking_fact)
+      allow(Facter).to receive(:version).and_return('3.0.0')
     end
     it 'uses the built-in facts to determine the primary interface' do
       # (rski) For some reason with ruby 1.9.3 this doesn't work in the before block
-      Facter.stubs(:version).returns('3.0.0')
       expect(Facter.fact(:network_primary_interface).value).to eq('eth1')
     end
   end

--- a/spec/unit/facts/network_primary_ip_spec.rb
+++ b/spec/unit/facts/network_primary_ip_spec.rb
@@ -3,13 +3,13 @@ require 'spec_helper'
 describe 'network_primary_ip' do
   before do
     Facter.clear
-    Facter.fact(:kernel).stubs(:value).returns('linux')
+    allow(Facter.fact(:kernel)).to receive(:value).and_return('linux')
   end
   context 'on a Linux host with Facter 2.x' do
     before do
-      Facter.stubs(:version).returns('2.4.6')
-      Facter::Util::Resolution.stubs(:exec).with('ip route show 0/0').returns('default via 1.2.3.4 dev eth0').once
-      Facter::Util::Resolution.stubs(:exec).with('ip route get 1.2.3.4').returns("1.2.3.4 dev eth0  src 1.2.3.99\n
+      allow(Facter).to receive(:version).and_return('2.4.6')
+      allow(Facter::Util::Resolution).to receive(:exec).with('ip route show 0/0').and_return('default via 1.2.3.4 dev eth0').once
+      allow(Facter::Util::Resolution).to receive(:exec).with('ip route get 1.2.3.4').and_return("1.2.3.4 dev eth0  src 1.2.3.99\n
   cache  mtu 1500 advmss 1460 hoplimit 64").once
     end
     it 'execs ip and determine the primary ip address' do
@@ -19,14 +19,13 @@ describe 'network_primary_ip' do
   context 'on an OpenVZ VM with Facter 2.x' do
     before do
       Facter.clear
-      Facter.stubs(:version).returns('2.4.6')
-      Facter.fact(:virtual).stubs(:value).returns('openvz')
-      Facter::Util::Resolution.stubs(:exec)
+      allow(Facter).to receive(:version).and_return('2.4.6')
+      allow(Facter.fact(:virtual)).to receive(:value).and_return('openvz')
     end
     context 'with only venet devices' do
       before do
-        Facter::Util::Resolution.stubs(:exec).with('ip route show 0/0').returns('default dev venet0  scope link')
-        Facter::Util::Resolution.stubs(:exec).with('ip route get 8.8.8.8').returns("8.8.8.8 dev venet0  src 1.2.3.99\n
+        allow(Facter::Util::Resolution).to receive(:exec).with('ip route show 0/0').and_return('default dev venet0  scope link')
+        allow(Facter::Util::Resolution).to receive(:exec).with('ip route get 8.8.8.8').and_return("8.8.8.8 dev venet0  src 1.2.3.99\n
   cache  mtu 1500 advmss 1460 hoplimit 64")
       end
       it 'execs ip and determine the primary ip address' do
@@ -36,16 +35,14 @@ describe 'network_primary_ip' do
   end
   context 'on a Linux host with Facter 3.x' do
     before do
-      Facter::Util::Resolution.expects(:exec).never
       ip_fact = Facter.fact(:network_primary_ip)
       networking_fact = Facter::Util::Fact.new(:networking)
-      networking_fact.expects(:value).returns('ip' => '2.3.4.5')
-      Facter.expects(:fact).with(:networking).returns(networking_fact)
-      Facter.expects(:fact).with(:network_primary_ip).returns(ip_fact)
+      allow(networking_fact).to receive(:value).and_return('ip' => '2.3.4.5')
+      allow(Facter).to receive(:fact).with(:networking).and_return(networking_fact)
+      allow(Facter).to receive(:fact).with(:network_primary_ip).and_return(ip_fact)
+      allow(Facter).to receive(:version).and_return('3.0.0')
     end
     it 'uses the built-in facts to resolve the primary ip address' do
-      # (rski) For some reason this doesn't work with ruby 1.9.3
-      Facter.stubs(:version).returns('3.0.0')
       expect(Facter.fact(:network_primary_ip).value).to eq('2.3.4.5')
     end
   end

--- a/spec/unit/provider/network_config/interfaces_spec.rb
+++ b/spec/unit/provider/network_config/interfaces_spec.rb
@@ -155,104 +155,104 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
 
   describe 'when formatting' do
     let(:eth0_provider) do
-      stub('eth0_provider',
-           name: 'eth0',
-           ensure: :present,
-           onboot: true,
-           hotplug: true,
-           family: 'inet',
-           method: 'static',
-           ipaddress: '169.254.0.1',
-           netmask: '255.255.0.0',
-           mtu: '1500',
-           mode: nil,
-           options: nil)
+      instance_double('eth0_provider',
+                      name: 'eth0',
+                      ensure: :present,
+                      onboot: true,
+                      hotplug: true,
+                      family: 'inet',
+                      method: 'static',
+                      ipaddress: '169.254.0.1',
+                      netmask: '255.255.0.0',
+                      mtu: '1500',
+                      mode: nil,
+                      options: nil)
     end
 
     let(:vlan20_provider) do
-      stub('vlan20_provider',
-           name: 'vlan20',
-           ensure: :present,
-           onboot: true,
-           hotplug: true,
-           family: 'inet',
-           method: 'static',
-           ipaddress: '169.254.0.1',
-           netmask: '255.255.0.0',
-           mtu: '1500',
-           mode: :vlan,
-           options: {
-             'vlan-raw-device' => 'eth1'
-           })
+      instance_double('vlan20_provider',
+                      name: 'vlan20',
+                      ensure: :present,
+                      onboot: true,
+                      hotplug: true,
+                      family: 'inet',
+                      method: 'static',
+                      ipaddress: '169.254.0.1',
+                      netmask: '255.255.0.0',
+                      mtu: '1500',
+                      mode: :vlan,
+                      options: {
+                        'vlan-raw-device' => 'eth1'
+                      })
     end
 
     let(:vlan10_provider) do
-      stub('vlan10_provider',
-           name: 'vlan10',
-           ensure: :present,
-           onboot: true,
-           hotplug: true,
-           family: 'inet',
-           method: 'dhcp',
-           ipaddress: nil,
-           netmask: nil,
-           mtu: nil,
-           mode: :vlan,
-           options: {})
+      instance_double('vlan10_provider',
+                      name: 'vlan10',
+                      ensure: :present,
+                      onboot: true,
+                      hotplug: true,
+                      family: 'inet',
+                      method: 'dhcp',
+                      ipaddress: nil,
+                      netmask: nil,
+                      mtu: nil,
+                      mode: :vlan,
+                      options: {})
     end
 
     let(:eth1_4500_provider) do
-      stub('eth1_4500_provider',
-           name: 'eth1.4500',
-           ensure: :present,
-           onboot: true,
-           hotplug: true,
-           family: 'inet',
-           method: 'dhcp',
-           ipaddress: nil,
-           netmask: nil,
-           mtu: nil,
-           mode: :vlan,
-           options: {})
+      instance_double('eth1_4500_provider',
+                      name: 'eth1.4500',
+                      ensure: :present,
+                      onboot: true,
+                      hotplug: true,
+                      family: 'inet',
+                      method: 'dhcp',
+                      ipaddress: nil,
+                      netmask: nil,
+                      mtu: nil,
+                      mode: :vlan,
+                      options: {})
     end
 
     let(:eth1_provider) do
-      stub('eth1_provider',
-           name: 'eth1',
-           ensure: :present,
-           onboot: false,
-           hotplug: true,
-           family: 'inet',
-           method: 'static',
-           ipaddress: '169.254.0.1',
-           netmask: '255.255.0.0',
-           mtu: '576',
-           mode: nil,
-           options: {
-             'pre-up'    => '/bin/touch /tmp/eth1-up',
-             'post-down' => [
-               '/bin/touch /tmp/eth1-down1',
-               '/bin/touch /tmp/eth1-down2'
-             ]
-           })
+      instance_double('eth1_provider',
+                      name: 'eth1',
+                      ensure: :present,
+                      onboot: false,
+                      hotplug: true,
+                      family: 'inet',
+                      method: 'static',
+                      ipaddress: '169.254.0.1',
+                      netmask: '255.255.0.0',
+                      mtu: '576',
+                      mode: nil,
+                      options: {
+                        'pre-up'    => '/bin/touch /tmp/eth1-up',
+                        'post-down' => [
+                          '/bin/touch /tmp/eth1-down1',
+                          '/bin/touch /tmp/eth1-down2'
+                        ]
+                      })
     end
 
     let(:lo_provider) do
-      stub('lo_provider',
-           name: 'lo',
-           onboot: true,
-           hotplug: false,
-           family: 'inet',
-           method: 'loopback',
-           ipaddress: nil,
-           netmask: nil,
-           mtu: '65536',
-           mode: nil,
-           options: nil)
+      instance_double('lo_provider',
+                      name: 'lo',
+                      onboot: true,
+                      hotplug: false,
+                      family: 'inet',
+                      method: 'loopback',
+                      ipaddress: nil,
+                      netmask: nil,
+                      mtu: '65536',
+                      mode: nil,
+                      options: nil)
     end
 
     before do
-      described_class.stubs(:header).returns "# HEADER: stubbed header\n"
+      allow(described_class).to receive(:header).and_return "# HEADER: stubbed header\n"
     end
 
     let(:content) { described_class.format_file('', [lo_provider, eth0_provider, eth1_provider]) } # rubocop:disable RSpec/ScatteredLet
@@ -311,14 +311,12 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
       end
 
       it 'fails if the family property is not defined' do
-        lo_provider.unstub(:family)
-        lo_provider.stubs(:family).returns nil
+        allow(lo_provider).to receive(:family).and_return(nil)
         expect { content }.to raise_exception(%r{does not have a family})
       end
 
       it 'fails if the method property is not defined' do
-        lo_provider.unstub(:method)
-        lo_provider.stubs(:method).returns nil
+        allow(lo_provider).to receive(:method).and_return(nil)
         expect { content }.to raise_exception(%r{does not have a method})
       end
     end

--- a/spec/unit/provider/network_config/redhat_spec.rb
+++ b/spec/unit/provider/network_config/redhat_spec.rb
@@ -110,11 +110,10 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       let(:virbonding_path) { File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'network_config', 'redhat_spec', 'virbonding') }
 
       before do
-        described_class.stubs(:target_files).returns Dir["#{virbonding_path}/*"]
+        allow(described_class).to receive(:target_files).and_return(Dir["#{virbonding_path}/*"])
       end
-
+      
       describe 'bond0' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'bond0' } }
 
@@ -128,7 +127,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'bond1' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'bond1' } }
 
@@ -144,7 +142,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth0' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'eth0' } }
 
@@ -161,8 +158,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth1' do
-        before { subject.expects(:select_file).never }
-
+        
         subject { described_class.instances.find { |i| i.name == 'eth1' } }
 
         its(:onboot) { is_expected.to be true }
@@ -178,7 +174,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth2' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'eth2' } }
 
@@ -195,7 +190,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth3' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'eth3' } }
 
@@ -212,7 +206,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'vlan100' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'vlan100' } }
 
@@ -231,7 +224,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'vlan100:0' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'vlan100:0' } }
 
@@ -243,7 +235,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'vlan200' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'vlan200' } }
 
@@ -261,7 +252,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'vlan300' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'vlan300' } }
 
@@ -279,7 +269,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'vlan400' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'vlan400' } }
 
@@ -297,7 +286,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'vlan500' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'vlan500' } }
 
@@ -319,11 +307,10 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       let(:network_scripts_path) { fixture_file('network-scripts') }
 
       before do
-        described_class.stubs(:target_files).returns Dir["#{network_scripts_path}/*"]
+        allow(described_class).to receive(:target_files).and_return(Dir["#{network_scripts_path}/*"])
       end
 
       describe 'eth0.0' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'eth0.0' } }
 
@@ -342,7 +329,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth0.1' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'eth0.1' } }
 
@@ -361,7 +347,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth0.4095' do
-        before { subject.expects(:select_file).never }
 
         subject { described_class.instances.find { |i| i.name == 'eth0.4095' } }
 
@@ -395,76 +380,76 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
 
   describe 'when formatting resources' do
     let(:eth0_provider) do
-      stub('eth0_provider',
-           name: 'eth0',
-           ensure: :present,
-           onboot: true,
-           hotplug: true,
-           family: 'inet',
-           method: 'none',
-           ipaddress: '169.254.0.1',
-           netmask: '255.255.255.0',
-           mtu: '1500',
-           mode: nil,
-           options: { 'NM_CONTROLLED' => 'no', 'USERCTL' => 'no' })
+      instance_double('eth0_provider',
+                      name: 'eth0',
+                      ensure: :present,
+                      onboot: true,
+                      hotplug: true,
+                      family: 'inet',
+                      method: 'none',
+                      ipaddress: '169.254.0.1',
+                      netmask: '255.255.255.0',
+                      mtu: '1500',
+                      mode: nil,
+                      options: { 'NM_CONTROLLED' => 'no', 'USERCTL' => 'no' })
     end
 
     let(:eth0_1_provider) do
-      stub('eth0_1_provider',
-           name: 'eth0.1',
-           ensure: :present,
-           onboot: true,
-           hotplug: true,
-           family: 'inet',
-           method: 'none',
-           ipaddress: '169.254.0.1',
-           netmask: '255.255.255.0',
-           mtu: '1500',
-           mode: :vlan,
-           options: { 'NM_CONTROLLED' => 'no', 'USERCTL' => 'no' })
+      instance_double('eth0_1_provider',
+                      name: 'eth0.1',
+                      ensure: :present,
+                      onboot: true,
+                      hotplug: true,
+                      family: 'inet',
+                      method: 'none',
+                      ipaddress: '169.254.0.1',
+                      netmask: '255.255.255.0',
+                      mtu: '1500',
+                      mode: :vlan,
+                      options: { 'NM_CONTROLLED' => 'no', 'USERCTL' => 'no' })
     end
 
     let(:eth1_provider) do
-      stub('eth1_provider',
-           name: 'eth1',
-           ensure: :present,
-           onboot: :absent,
-           hotplug: true,
-           family: 'inet',
-           method: 'none',
-           ipaddress: :absent,
-           netmask: :absent,
-           mtu: :absent,
-           mode: :vlan,
-           options: :absent)
+      instance_double('eth1_provider',
+                      name: 'eth1',
+                      ensure: :present,
+                      onboot: :absent,
+                      hotplug: true,
+                      family: 'inet',
+                      method: 'none',
+                      ipaddress: :absent,
+                      netmask: :absent,
+                      mtu: :absent,
+                      mode: :vlan,
+                      options: :absent)
     end
 
     let(:lo_provider) do
-      stub('lo_provider',
-           name: 'lo',
-           onboot: true,
-           hotplug: true,
-           family: 'inet',
-           method: 'loopback',
-           ipaddress: nil,
-           netmask: nil,
-           mode: nil,
-           options: {})
+      instance_double('lo_provider',
+                      name: 'lo',
+                      onboot: true,
+                      hotplug: true,
+                      family: 'inet',
+                      method: 'loopback',
+                      ipaddress: nil,
+                      netmask: nil,
+                      mode: nil,
+                      options: {})
     end
 
     let(:bond0_provider) do
-      stub('bond0_provider',
-           name: 'bond0',
-           onboot: true,
-           hotplug: true,
-           ipaddress: '172.20.1.9',
-           netmask: '255.255.255.0',
-           method: 'static',
-           mtu: '1500',
-           mode: nil,
-           options: {
-             'BONDING_OPTS' => %(mode=4 miimon=100 xmit_hash_policy=layer3+4)
-           })
+      instance_double('bond0_provider',
+                      name: 'bond0',
+                      onboot: true,
+                      hotplug: true,
+                      ipaddress: '172.20.1.9',
+                      netmask: '255.255.255.0',
+                      method: 'static',
+                      mtu: '1500',
+                      mode: nil,
+                      options: {
+                        'BONDING_OPTS' => %(mode=4 miimon=100 xmit_hash_policy=layer3+4)
+                      })
     end
 
     it 'fails if multiple interfaces are flushed to one file' do
@@ -515,12 +500,17 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
   end
 
   describe 'when flushing a dirty file' do
+    before do
+      allow(File).to receive(:chmod).with(0o644, '/not/a/real/file')
+      allow(File).to receive(:unlink)
+      allow(described_class).to receive(:perform_write)
+    end
     it do
-      File.expects(:chmod).with(0o644, '/not/a/real/file')
-      File.expects(:unlink).never
-      described_class.stubs(:perform_write)
       described_class.dirty_file!('/not/a/real/file')
       described_class.flush_file('/not/a/real/file')
+    end
+    it 'is expected that it shouldnot have have unlinked the file' do
+      expect(File).not_to have_received(:unlink)
     end
   end
 end

--- a/spec/unit/provider/network_config/redhat_spec.rb
+++ b/spec/unit/provider/network_config/redhat_spec.rb
@@ -112,9 +112,8 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       before do
         allow(described_class).to receive(:target_files).and_return(Dir["#{virbonding_path}/*"])
       end
-      
-      describe 'bond0' do
 
+      describe 'bond0' do
         subject { described_class.instances.find { |i| i.name == 'bond0' } }
 
         its(:onboot) { is_expected.to be true }
@@ -127,7 +126,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'bond1' do
-
         subject { described_class.instances.find { |i| i.name == 'bond1' } }
 
         its(:onboot)    { is_expected.to be true }
@@ -142,7 +140,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth0' do
-
         subject { described_class.instances.find { |i| i.name == 'eth0' } }
 
         its(:onboot) { is_expected.to be true }
@@ -158,7 +155,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth1' do
-        
         subject { described_class.instances.find { |i| i.name == 'eth1' } }
 
         its(:onboot) { is_expected.to be true }
@@ -174,7 +170,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth2' do
-
         subject { described_class.instances.find { |i| i.name == 'eth2' } }
 
         its(:onboot) { is_expected.to be true }
@@ -190,7 +185,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth3' do
-
         subject { described_class.instances.find { |i| i.name == 'eth3' } }
 
         its(:onboot) { is_expected.to be true }
@@ -206,7 +200,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'vlan100' do
-
         subject { described_class.instances.find { |i| i.name == 'vlan100' } }
 
         its(:ipaddress) { is_expected.to eq('172.24.61.11') }
@@ -224,7 +217,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'vlan100:0' do
-
         subject { described_class.instances.find { |i| i.name == 'vlan100:0' } }
 
         its(:ipaddress) { is_expected.to eq('172.24.61.12') }
@@ -235,7 +227,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'vlan200' do
-
         subject { described_class.instances.find { |i| i.name == 'vlan200' } }
 
         its(:ipaddress) { is_expected.to eq('172.24.62.1') }
@@ -252,7 +243,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'vlan300' do
-
         subject { described_class.instances.find { |i| i.name == 'vlan300' } }
 
         its(:ipaddress) { is_expected.to eq('172.24.63.1') }
@@ -269,7 +259,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'vlan400' do
-
         subject { described_class.instances.find { |i| i.name == 'vlan400' } }
 
         its(:ipaddress) { is_expected.to eq('172.24.64.1') }
@@ -286,7 +275,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'vlan500' do
-
         subject { described_class.instances.find { |i| i.name == 'vlan500' } }
 
         its(:ipaddress) { is_expected.to eq('172.24.65.1') }
@@ -311,7 +299,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth0.0' do
-
         subject { described_class.instances.find { |i| i.name == 'eth0.0' } }
 
         its(:onboot) { is_expected.to be true }
@@ -329,7 +316,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth0.1' do
-
         subject { described_class.instances.find { |i| i.name == 'eth0.1' } }
 
         its(:onboot) { is_expected.to be true }
@@ -347,7 +333,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
 
       describe 'eth0.4095' do
-
         subject { described_class.instances.find { |i| i.name == 'eth0.4095' } }
 
         its(:onboot) { is_expected.to be true }

--- a/spec/unit/provider/network_route/redhat_spec.rb
+++ b/spec/unit/provider/network_route/redhat_spec.rb
@@ -79,7 +79,7 @@ describe Puppet::Type.type(:network_route).provider(:redhat) do
 
   describe 'when formatting' do
     let :route1_provider do
-      stub(
+      instance_double(
         'route1_provider',
         name: '172.17.67.0/30',
         network: '172.17.67.0',
@@ -91,7 +91,7 @@ describe Puppet::Type.type(:network_route).provider(:redhat) do
     end
 
     let :route2_provider do
-      stub(
+      instance_double(
         'lo_provider',
         name: '172.28.45.0/30',
         network: '172.28.45.0',
@@ -103,7 +103,7 @@ describe Puppet::Type.type(:network_route).provider(:redhat) do
     end
 
     let :defaultroute_provider do
-      stub(
+      instance_double(
         'defaultroute_provider',
         name: 'default',
         network: 'default',
@@ -115,7 +115,7 @@ describe Puppet::Type.type(:network_route).provider(:redhat) do
     end
 
     let :nooptions_provider do
-      stub(
+      instance_double(
         'nooptions_provider',
         name: 'default',
         network: 'default',
@@ -145,14 +145,12 @@ describe Puppet::Type.type(:network_route).provider(:redhat) do
         end
 
         it 'fails if the netmask property is not defined' do
-          route2_provider.unstub(:netmask)
-          route2_provider.stubs(:netmask).returns nil
+          allow(route2_provider).to receive(:netmask).and_return(nil)
           expect { content }.to raise_exception(%r{is missing the required parameter 'netmask'})
         end
 
         it 'fails if the gateway property is not defined' do
-          route2_provider.unstub(:gateway)
-          route2_provider.stubs(:gateway).returns nil
+          allow(route2_provider).to receive(:gateway).and_return(nil)
           expect { content }.to raise_exception(%r{is missing the required parameter 'gateway'})
         end
       end

--- a/spec/unit/provider/network_route/routes_spec.rb
+++ b/spec/unit/provider/network_route/routes_spec.rb
@@ -84,7 +84,7 @@ describe Puppet::Type.type(:network_route).provider(:routes) do
 
   describe 'when formatting' do
     let :route1_provider do
-      stub(
+      instance_double(
         'route1_provider',
         name: '172.17.67.0',
         network: '172.17.67.0',
@@ -96,7 +96,7 @@ describe Puppet::Type.type(:network_route).provider(:routes) do
     end
 
     let :route2_provider do
-      stub(
+      instance_double(
         'lo_provider',
         name: '172.28.45.0',
         network: '172.28.45.0',
@@ -124,21 +124,19 @@ describe Puppet::Type.type(:network_route).provider(:routes) do
       end
 
       it 'fails if the netmask property is not defined' do
-        route2_provider.unstub(:netmask)
-        route2_provider.stubs(:netmask).returns nil
+        allow(route2_provider).to receive(:netmask).and_return(nil)
         expect { content }.to raise_exception(%r{is missing the required parameter 'netmask'})
       end
 
       it 'fails if the gateway property is not defined' do
-        route2_provider.unstub(:gateway)
-        route2_provider.stubs(:gateway).returns nil
+        allow(route2_provider).to receive(:gateway).and_return(nil)
         expect { content }.to raise_exception(%r{is missing the required parameter 'gateway'})
       end
     end
   end
   describe 'when formatting simple files' do
     let :route1_provider do
-      stub(
+      instance_double(
         'route1_provider',
         name: '172.17.67.0',
         network: '172.17.67.0',
@@ -150,7 +148,7 @@ describe Puppet::Type.type(:network_route).provider(:routes) do
     end
 
     let :route2_provider do
-      stub(
+      instance_double(
         'lo_provider',
         name: '172.28.45.0',
         network: '172.28.45.0',
@@ -179,14 +177,12 @@ describe Puppet::Type.type(:network_route).provider(:routes) do
       end
 
       it 'fails if the netmask property is not defined' do
-        route2_provider.unstub(:netmask)
-        route2_provider.stubs(:netmask).returns nil
+        allow(route2_provider).to receive(:netmask).and_return(nil)
         expect { content }.to raise_exception(%r{is missing the required parameter 'netmask'})
       end
 
       it 'fails if the gateway property is not defined' do
-        route2_provider.unstub(:gateway)
-        route2_provider.stubs(:gateway).returns nil
+        allow(route2_provider).to receive(:gateway).and_return(nil)
         expect { content }.to raise_exception(%r{is missing the required parameter 'gateway'})
       end
     end

--- a/spec/unit/type/network_config_spec.rb
+++ b/spec/unit/type/network_config_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:network_config) do
   before do
-    provider_class = stub 'provider class', name: 'fake', suitable?: true, supports_parameter?: true
-    provider_class.stubs(:new)
-
-    Puppet::Type.type(:network_config).stubs(:defaultprovider).returns provider_class
-    Puppet::Type.type(:network_config).stubs(:provider).returns provider_class
+    provider_class = instance_double 'provider class'
+    allow(provider_class).to receive(:name).and_return('fake')
+    allow(provider_class).to receive(:suitable?).and_return(true)
+    allow(provider_class).to receive(:supports_parameter?).and_return(true)
+    allow(provider_class).to receive(:new)
+    allow(Puppet::Type.type(:network_config)).to receive(:defaultprovider).and_return(provider_class)
+    allow(Puppet::Type.type(:network_config)).to receive(:provider).and_return(provider_class)
   end
-
   describe 'feature' do
     describe 'hotpluggable' do
       it { expect(Puppet::Type.type(:network_config).provider_feature(:hotpluggable)).not_to be_nil }

--- a/spec/unit/type/network_route_spec.rb
+++ b/spec/unit/type/network_route_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:network_route) do
   before do
-    provider_class = stub 'provider class', name: 'fake', suitable?: true, supports_parameter?: true
-    provider_class.stubs(:new)
-
-    Puppet::Type.type(:network_route).stubs(:defaultprovider).returns provider_class
-    Puppet::Type.type(:network_route).stubs(:provider).returns provider_class
+    provider_class = instance_double 'provider class'
+    allow(provider_class).to receive(:name).and_return('fake')
+    allow(provider_class).to receive(:suitable?).and_return(true)
+    allow(provider_class).to receive(:supports_parameter?).and_return(true)
+    allow(provider_class).to receive(:new)
+    allow(Puppet::Type.type(:network_route)).to receive(:defaultprovider).and_return(provider_class)
+    allow(Puppet::Type.type(:network_route)).to receive(:provider).and_return(provider_class)
   end
-
   describe 'when validating the attribute' do
     describe :name do # rubocop:disable RSpec/DescribeSymbol
       it { expect(Puppet::Type.type(:network_route).attrtype(:name)).to eq(:param) }


### PR DESCRIPTION
This PR converts the existing testsuite to rspec as opposed to mocha, this is a precursor to the refactoring of this provider into the Puppet Resource API
