### PR TITLE
Don't prefix facts with `:`

### DIFF
--- a/lib/facter/network.rb
+++ b/lib/facter/network.rb
@@ -1,6 +1,6 @@
 require 'facter'
 
-Facter.add(':network_nexthop_ip') do
+Facter.add(:network_nexthop_ip) do
   confine kernel: 'Linux'
   confine { Facter::Util::Resolution.which('ip') }
   my_gw = nil
@@ -13,7 +13,7 @@ Facter.add(':network_nexthop_ip') do
   end
 end
 
-Facter.add(':network_primary_interface') do
+Facter.add(:network_primary_interface) do
   confine kernel: 'Linux'
 
   setcode do
@@ -21,7 +21,7 @@ Facter.add(':network_primary_interface') do
   end
 end
 
-Facter.add(':network_primary_ip') do
+Facter.add(:network_primary_ip) do
   confine kernel: 'Linux'
 
   setcode do

--- a/spec/unit/facter/network_nexthop_ip_spec.rb
+++ b/spec/unit/facter/network_nexthop_ip_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 require 'facter'
 require 'facter/network'
 
-describe ':network_nexthop_ip', type: :fact do
-  subject(:fact) { Facter.fact(':network_nexthop_ip') }
+describe 'network_nexthop_ip fact' do
+  subject(:fact) { Facter.fact(:network_nexthop_ip) }
 
   before do
     # perform any action that should be run before every test

--- a/spec/unit/facter/network_primary_interface_spec.rb
+++ b/spec/unit/facter/network_primary_interface_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 require 'facter'
 require 'facter/network'
 
-describe ':network_primary_interface', type: :fact do
-  subject(:fact) { Facter.fact(':network_primary_interface') }
+describe 'network_primary_interface' do
+  subject(:fact) { Facter.fact(:network_primary_interface) }
 
   before do
     Facter.clear

--- a/spec/unit/facter/network_primary_ip_spec.rb
+++ b/spec/unit/facter/network_primary_ip_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 require 'facter'
 require 'facter/network'
 
-describe ':network_primary_ip', type: :fact do
-  subject(:fact) { Facter.fact(':network_primary_ip') }
+describe 'network_primary_ip' do
+  subject(:fact) { Facter.fact(:network_primary_ip) }
 
   before do
     Facter.clear


### PR DESCRIPTION
due to a quoting issue, the facts had a leading :. This was supposed to
be a symbol.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
