### PR TITLE
Attempt to fix nil:Class errors in RHEL

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,6 +14,7 @@ Lint/ConstantDefinitionInBlock:
     - 'lib/puppet/provider/network_config/interfaces.rb'
     - 'lib/puppet/provider/network_config/redhat.rb'
     - 'lib/puppet/provider/network_route/routes.rb'
+    - 'lib/puppet/provider/network_route/redhat.rb'
 
 # Offense count: 2
 # Configuration parameters: IgnoreLiteralBranches, IgnoreConstantBranches.
@@ -56,6 +57,7 @@ Style/FrozenStringLiteralComment:
 Style/HashEachMethods:
   Exclude:
     - 'lib/puppet/provider/network_config/redhat.rb'
+    - 'lib/puppet/provider/network_route/redhat.rb'
 
 # Offense count: 3
 # Cop supports --auto-correct.
@@ -64,6 +66,7 @@ Style/HashEachMethods:
 Style/MutableConstant:
   Exclude:
     - 'lib/puppet/provider/network_config/redhat.rb'
+    - 'lib/puppet/provider/network_route/redhat.rb'
 
 # Offense count: 5
 # Cop supports --auto-correct.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,6 @@ Lint/ConstantDefinitionInBlock:
     - 'lib/puppet/provider/network_config/interfaces.rb'
     - 'lib/puppet/provider/network_config/redhat.rb'
     - 'lib/puppet/provider/network_route/routes.rb'
-    - 'lib/puppet/provider/network_route/redhat.rb'
 
 # Offense count: 2
 # Configuration parameters: IgnoreLiteralBranches, IgnoreConstantBranches.
@@ -57,7 +56,6 @@ Style/FrozenStringLiteralComment:
 Style/HashEachMethods:
   Exclude:
     - 'lib/puppet/provider/network_config/redhat.rb'
-    - 'lib/puppet/provider/network_route/redhat.rb'
 
 # Offense count: 3
 # Cop supports --auto-correct.
@@ -66,7 +64,6 @@ Style/HashEachMethods:
 Style/MutableConstant:
   Exclude:
     - 'lib/puppet/provider/network_config/redhat.rb'
-    - 'lib/puppet/provider/network_route/redhat.rb'
 
 # Offense count: 5
 # Cop supports --auto-correct.

--- a/lib/puppet/provider/network_config/redhat.rb
+++ b/lib/puppet/provider/network_config/redhat.rb
@@ -97,6 +97,11 @@ Puppet::Type.type(:network_config).provide(:redhat) do
 
     pair_regex = %r{^\s*(.+?)\s*=\s*(.*)\s*$}
 
+    # INFO: It is valid ifcfg format to include certain functions and strings these should not be reported as errors, but silently removed before parsing
+    # https://bugs.centos.org/bug_view_page.php?bug_id=475
+    # Remove lines with no = sign
+    lines.select! { |line| line =~ %r{^.*=.*$} }
+
     # Convert the data into key/value pairs
     pairs = lines.each_with_object({}) do |line, hash|
       raise Puppet::Error, %(#{filename} is malformed; "#{line}" did not match "#{pair_regex}") unless line.match(pair_regex) do |m|

--- a/lib/puppet/provider/network_route/redhat.rb
+++ b/lib/puppet/provider/network_route/redhat.rb
@@ -19,15 +19,15 @@ Puppet::Type.type(:network_route).provide(:redhat) do
   has_feature :provider_options
 
   # @return [String] The path to network-script directory on redhat systems
-  SCRIPT_DIRECTORY_ROUTE = '/etc/sysconfig/network-scripts'.freeze
+  _script_directory_route = '/etc/sysconfig/network-scripts'.freeze
 
   def select_file
-    "#{SCRIPT_DIRECTORY_ROUTE}/route-#{interface}"
+    "#{_script_directory_route}/route-#{interface}"
   end
 
-  def self.target_files(script_dir = SCRIPT_DIRECTORY_ROUTE)
+  def self.target_files(script_dir = _script_directory_route)
     entries = Dir.entries(script_dir).select { |entry| entry.match %r{route-.*} }
-    entries.map { |entry| File.join(SCRIPT_DIRECTORY_ROUTE, entry) }
+    entries.map { |entry| File.join(_script_directory_route, entry) }
   end
 
   def self.parse_file(_filename, contents)

--- a/lib/puppet/provider/network_route/redhat.rb
+++ b/lib/puppet/provider/network_route/redhat.rb
@@ -18,21 +18,17 @@ Puppet::Type.type(:network_route).provide(:redhat) do
 
   has_feature :provider_options
 
-  # @return [String] The path to network-script directory on redhat systems
-  _script_directory_route = '/etc/sysconfig/network-scripts'.freeze
-
   def select_file
-    "#{_script_directory_route}/route-#{interface}"
+    "/etc/sysconfig/network-scripts/route-#{interface}"
   end
 
-  def self.target_files(script_dir = _script_directory_route)
+  def self.target_files(script_dir = '/etc/sysconfig/network-scripts')
     entries = Dir.entries(script_dir).select { |entry| entry.match %r{route-.*} }
-    entries.map { |entry| File.join(_script_directory_route, entry) }
+    entries.map { |entry| File.join(script_dir, entry) }
   end
 
   def self.parse_file(_filename, contents)
     routes = []
-
     lines = contents.split("\n")
     lines.each do |line|
       # Strip off any trailing comments

--- a/spec/unit/provider/network_config/redhat_spec.rb
+++ b/spec/unit/provider/network_config/redhat_spec.rb
@@ -364,12 +364,6 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
     end
 
-    describe 'when reading an invalid interfaces' do
-      it 'with a mangled key/value should fail' do
-        expect { described_class.parse_file('eth0', 'DEVICE: eth0') }.to raise_error Puppet::Error, %r{malformed}
-      end
-    end
-
     describe 'when DEVICE is not present' do
       let(:data) { described_class.parse_file('ifcfg-eth1', fixture_data('eth1-dhcp'))[0] }
 


### PR DESCRIPTION
#### Pull Request (PR) description

- Fix Redhat Failures with FileMapper
- As far as I can tell this has never worked with redhat, not sure how to proceed the problem seems to be in
FileMapper
- I need input from Devs owning FileMapper @bastelfreak maybe?
- The following code fixes the error in Centos 7+8 but now the systems fails to track state properly and reports changes on every run obviously [] to self.target_files isn't ideal.
- Is FileMapper using :network as the key identifier or is it using :name? I can't tell
- Open Problem, resource name MUST match cidr format in order for parse_files to work properly

If you can give feedback I'll keep working on this

#### This Pull Request (PR) fixes the following issues

Fixes #66 
Fixes #64 
Fixes #11
Related to https://github.com/voxpupuli/puppet-filemapper/issues/11
Related to #75 



