### PR TITLE
Enable bonded interfaces on Debian-based distros instead of explicitly disabling them, to allow bonds to work correctly

### DIFF
--- a/manifests/bond/debian.pp
+++ b/manifests/bond/debian.pp
@@ -61,9 +61,17 @@ define network::bond::debian (
     options   => $opts,
   }
 
+  $opts_slave = merge( {
+      'bond-master' => $name,
+    },
+    $slave_options
+  )
+
   network_config { $slaves:
-    ensure      => absent,
-    reconfigure => true,
-    before      => Network_config[$name],
+    ensure  => $ensure,
+    method  => 'manual',
+    onboot  => true,
+    hotplug => false,
+    options => $opts_slave,
   }
 }

--- a/manifests/bond/debian.pp
+++ b/manifests/bond/debian.pp
@@ -2,6 +2,12 @@
 #
 # Instantiate bonded interfaces on Debian based systems.
 #
+# == Notes
+#
+# systemd-networkd and netplan need to be disabled or removed on
+# recent versions of Ubuntu at least, as they conflict with static
+# network configs in /etc/network/interfaces which this uses.
+#
 # == See also
 #
 # * Debian Network Bonding http://wiki.debian.org/Bonding


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Set bond member interfaces to be enabled or disabled with the main interface, as disabled member interfaces on an enabled bond do not become a member of the bond as expected.

#### This Pull Request (PR) fixes the following issues

Fixes #288 
