### PR TITLE
Replace the IPAddress gem with the built-in IPAddr class

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This module requires the FileMapper mixin, available at <https://github.com/voxp
 The network_config type requires the Boolean mixin, available at <https://github.com/adrienthebo/puppet-boolean>.
 
 The debian routes provider requires the package [ifupdown-extra](http://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=ifupdown-extra).
-`ifupdown-extra` and `ipaddress` can be installed automatically using the `network` class.
+`ifupdown-extra` can be installed automatically using the `network` class.
 To use it, include it like so in your manifests:
 
 ```puppet

--- a/README.md
+++ b/README.md
@@ -111,10 +111,8 @@ This module requires the FileMapper mixin, available at <https://github.com/voxp
 The network_config type requires the Boolean mixin, available at <https://github.com/adrienthebo/puppet-boolean>.
 
 The debian routes provider requires the package [ifupdown-extra](http://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=ifupdown-extra).
-The `network_config` class requires the `ipaddress` gem, which needs to be
-installed on both the puppet master and the nodes. `ifupdown-extra` and
-`ipaddress` can be installed automatically using the `network` class. To use it,
-include it like so in your manifests:
+`ifupdown-extra` and `ipaddress` can be installed automatically using the `network` class.
+To use it, include it like so in your manifests:
 
 ```puppet
 include '::network'

--- a/README.md
+++ b/README.md
@@ -122,10 +122,6 @@ This class also provides fine-grained control over which packages to install and
 how to install them. The documentation for the parameters exposed can be found
 [here](https://github.com/voxpupuli/puppet-network/blob/master/manifests/init.pp).
 
-The `ipaddress` gem can also be installed manually with:
-
-    sudo gem install ipaddress --no-ri --no-rdoc
-
 Note: you may also need to update your master's plugins (run on your puppet master):
 
     puppet agent -t --noop

--- a/lib/puppet/type/network_config.rb
+++ b/lib/puppet/type/network_config.rb
@@ -33,11 +33,9 @@ Puppet::Type.newtype(:network_config) do
     desc 'The IP address of the network interfaces'
     if defined? IPAddr
       validate do |value|
-        begin
-          ipa = IPAddr.new value
-        rescue IPAddr::InvalidAddressError
-          raise ArgumentError, "#{self.class} requires a valid ipaddress for the ipaddress property"
-        end
+        IPAddr.new value
+      rescue IPAddr::InvalidAddressError
+        raise ArgumentError, "#{self.class} requires a valid ipaddress for the ipaddress property"
         # provider.validate
       end
     end
@@ -47,16 +45,14 @@ Puppet::Type.newtype(:network_config) do
     desc 'The subnet mask to apply to the interface'
     if defined? IPAddr
       validate do |value|
+        ipa = IPAddr.new '127.0.0.1'
+        ipa.mask(value)
+      rescue IPAddr::InvalidAddressError
         begin
-          ipa = IPAddr.new '127.0.0.1'
-          ipa.mask(value)
+          ipz = IPAddr.new '::1'
+          ipz.mask(value)
         rescue IPAddr::InvalidAddressError
-          begin
-            ipz = IPAddr.new '::1'
-            ipz.mask(value)
-          rescue IPAddr::InvalidAddressError
-            raise ArgumentError, "#{self.class} requires a valid netmask for the netmask property"
-          end
+          raise ArgumentError, "#{self.class} requires a valid netmask for the netmask property"
         end
         # provider.validate
       end

--- a/lib/puppet/type/network_config.rb
+++ b/lib/puppet/type/network_config.rb
@@ -1,9 +1,9 @@
 require 'puppet/property/boolean'
 
 begin
-  require 'ipaddress'
+  require 'ipaddr'
 rescue LoadError
-  Puppet.warning("#{__FILE__}:#{__LINE__}: ipaddress gem was not found")
+  Puppet.warning("#{__FILE__}:#{__LINE__}: ipaddr gem was not found")
 end
 
 Puppet::Type.newtype(:network_config) do
@@ -31,9 +31,13 @@ Puppet::Type.newtype(:network_config) do
 
   newproperty(:ipaddress) do
     desc 'The IP address of the network interfaces'
-    if defined? IPAddress
+    if defined? IPAddr
       validate do |value|
-        raise ArgumentError, "#{self.class} requires a valid ipaddress for the ipaddress property" unless IPAddress.valid? value
+        begin
+          ipa = IPAddr.new value
+        rescue IPAddr::InvalidAddressError
+          raise ArgumentError, "#{self.class} requires a valid ipaddress for the ipaddress property"
+        end
         # provider.validate
       end
     end
@@ -41,9 +45,19 @@ Puppet::Type.newtype(:network_config) do
 
   newproperty(:netmask) do
     desc 'The subnet mask to apply to the interface'
-    if defined? IPAddress
+    if defined? IPAddr
       validate do |value|
-        raise ArgumentError, "#{self.class} requires a valid netmask for the netmask property" unless IPAddress.valid_ipv4_netmask? value
+        begin
+          ipa = IPAddr.new '127.0.0.1'
+          ipa.mask(value)
+        rescue IPAddr::InvalidAddressError
+          begin
+            ipz = IPAddr.new '::1'
+            ipz.mask(value)
+          rescue IPAddr::InvalidAddressError
+            raise ArgumentError, "#{self.class} requires a valid netmask for the netmask property"
+          end
+        end
         # provider.validate
       end
     end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,40 +28,12 @@
 #
 # Default: present
 #
-# [*ipaddress*]
-#
-# The name of the ipaddress gems
-#
-# Default: ipaddress
-#
-# [*ipaddress_provider*]
-#
-# The provider of the ipaddress gem
-#
-# Default: gem
-#
-# [*manage_ipaddress*]
-#
-# Whether this class should manage the ipaddress gem
-#
-# Default: true
-#
-# [*ensure_ipaddress*]
-#
-# What state the ifupdown-extra package should be in
-#
-# Default: present
-#
 
 class network (
   $ifupdown_extra          = 'ifupdown-extra',
   $ifupdown_extra_provider = undef,
   $manage_ifupdown_extra   = true,
   $ensure_ifupdown_extra   = present,
-  $ipaddress               = 'ipaddress',
-  $ipaddress_provider      = 'puppet_gem',
-  $manage_ipaddress        = true,
-  $ensure_ipaddress        = present,
 ) {
   if $facts['os']['family'] == 'Debian' and $manage_ifupdown_extra {
     package { $ifupdown_extra:
@@ -69,13 +41,5 @@ class network (
       provider => $ifupdown_extra_provider,
     }
     Package[$ifupdown_extra] -> Network_route <| |>
-  }
-
-  if $manage_ipaddress {
-    package { $ipaddress:
-      ensure   => $ensure_ipaddress,
-      provider => $ipaddress_provider,
-    }
-    Package[$ipaddress] -> Network_config <| |>
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,12 +28,40 @@
 #
 # Default: present
 #
+# [*ipaddress*]
+#
+# The name of the ipaddress gems
+#
+# Default: ipaddress
+#
+# [*ipaddress_provider*]
+#
+# The provider of the ipaddress gem
+#
+# Default: gem
+#
+# [*manage_ipaddress*]
+#
+# Whether this class should manage the ipaddress gem
+#
+# Default: true
+#
+# [*ensure_ipaddress*]
+#
+# What state the ipaddress package should be in
+#
+# Default: absent
+#
 
 class network (
   $ifupdown_extra          = 'ifupdown-extra',
   $ifupdown_extra_provider = undef,
   $manage_ifupdown_extra   = true,
   $ensure_ifupdown_extra   = present,
+  $ipaddress               = 'ipaddress',
+  $ipaddress_provider      = 'puppet_gem',
+  $manage_ipaddress        = true,
+  $ensure_ipaddress        = absent,
 ) {
   if $facts['os']['family'] == 'Debian' and $manage_ifupdown_extra {
     package { $ifupdown_extra:
@@ -41,5 +69,13 @@ class network (
       provider => $ifupdown_extra_provider,
     }
     Package[$ifupdown_extra] -> Network_route <| |>
+  }
+
+  if $manage_ipaddress {
+    package { $ipaddress:
+      ensure   => $ensure_ipaddress,
+      provider => $ipaddress_provider,
+    }
+    Package[$ipaddress] -> Network_config <| |>
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
The module relies on the [IPAddress](https://rubygems.org/gems/ipaddress) gem to perform certain validations.
It can be replaced by the [IPAddr](https://github.com/ruby/ipaddr) class, which does not require custom gem installation as it's part of the standard ruby distribution.

This pull request removes traces to the IPAddress gem in favour of the IPAddr class.

#### This Pull Request (PR) fixes the following issues
This should also fix #267
