### PR TITLE
Allow for setting 'options' in network_route on RHEL-like OS's

### DIFF
--- a/lib/puppet/type/network_route.rb
+++ b/lib/puppet/type/network_route.rb
@@ -4,6 +4,11 @@ require_relative '../../puppet_x/voxpupuli/utils'
 Puppet::Type.newtype(:network_route) do
   @doc = 'Manage non-volatile route configuration information'
 
+  feature :provider_options, <<-EOD
+    The provider can accept a hash of arbitrary options. The semantics of
+    these options will depend on the provider.
+  EOD
+
   include PuppetX::Voxpupuli::Utils
 
   ensurable


### PR DESCRIPTION
## Problem

Prior to this, the `network_route` type would not manage the `options` property on RHEL-like OS's.

For example, on RHEL 7, the `options` property of `"table foo"` would be completely ignored and not managed by Puppet:
```puppet
network_route { '10.10.0.0/16':
  ensure    => 'present',
  gateway   => '10.10.0.5',
  interface => 'eth1',
  netmask   => '255.255.0.0',
  network   => '10.10.0.0',
  options   => 'table foo',
}
```

## Solution

The problem was caused by a missing `feature` specification in the type. So that specification is being added.

## Outcome

The `options` property of a `network_route` can be managed by Puppet on RHEL-like OS's.

Fixes #295 

## Validation

✅ Updated the type as per this change and did a `puppet apply` against the reproduction case code
```
$ facter os.family
RedHat

$ sudo puppet apply network_route.pp
Notice: Compiled catalog for node in environment production in 0.06 seconds
Notice: /Stage[main]/Main/Network_route[10.10.0.0/16]/options: defined 'options' as 'table foo'
Notice: Applied catalog in 0.20 seconds

$ grep foo /etc/sysconfig/network-scripts/route-eth1
10.10.0.0/16 via 10.20.20.1 dev eth1 table foo
```