### PR TITLE
change name of debian package from ifenslave-2.6 to ifenslave

### DIFF
--- a/manifests/bond/setup.pp
+++ b/manifests/bond/setup.pp
@@ -2,7 +2,7 @@
 class network::bond::setup {
   case $facts['os']['family'] {
     'Debian': {
-      package { 'ifenslave-2.6':
+      package { 'ifenslave':
         ensure => present,
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,9 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "9",
+        "10",
+        "11"
       ]
     }
   ],

--- a/spec/classes/bond/setup_spec.rb
+++ b/spec/classes/bond/setup_spec.rb
@@ -8,6 +8,6 @@ describe 'network::bond::setup', type: :class do
       }
     end
 
-    it { is_expected.to contain_package('ifenslave-2.6') }
+    it { is_expected.to contain_package('ifenslave') }
   end
 end


### PR DESCRIPTION
Starting from Debian 9, ifenslave-2.6 is marked as 'transitional package, use ifenslave'. In debian 11 and 12, the ifenslave-2.6 package is no longer available, causing puppet run failure. https://packages.debian.org/search?searchon=names&keywords=ifenslave


#### Pull Request (PR) description

Update the name of the ifenslave package.

#### This Pull Request (PR) fixes the following issues

Fixes #305 
-->
