### PR TITLE
Update redhat.rb

### DIFF
--- a/lib/puppet/provider/network_config/redhat.rb
+++ b/lib/puppet/provider/network_config/redhat.rb
@@ -29,7 +29,7 @@ Puppet::Type.type(:network_config).provide(:redhat) do
   ALIAS_REGEX = %r{.{1,12}(?<!~|\.bak|\.old|\.orig|\.rpmnew|\.rpmorig|\.rpmsave)}
 
   # @return [Regexp] The regular expression for interface scripts on redhat systems
-  SCRIPT_REGEX = %r{\Aifcfg-[a-z]+[a-z\d]+(?::#{ALIAS_REGEX}|\.#{VLAN_RANGE_REGEX})?\Z}
+  SCRIPT_REGEX = %r{\Aifcfg-[a-z]+[a-z\d\.]+(?::#{ALIAS_REGEX}|\.#{VLAN_RANGE_REGEX})?\Z}
 
   NAME_MAPPINGS = {
     ipaddress: 'IPADDR',


### PR DESCRIPTION
#### Pull Request (PR) description

We have a few servers with interface names with a "." in, such as "ifcfg-bond0.12". Although it was working fine, whenever the puppet agent would run, it'd keep replacing the network file with a new one. Changing regex pattern to include interface names with dots (.) fixes this.

#### This Pull Request (PR) fixes the following issues

# Include interface names with dots in