### PR TITLE
Ensure boolean properties munged

### DIFF
--- a/lib/puppet/provider/network_config/redhat.rb
+++ b/lib/puppet/provider/network_config/redhat.rb
@@ -170,8 +170,8 @@ Puppet::Type.type(:network_config).provide(:redhat) do
     # For all of the remaining values, blindly toss them into the options hash.
     props[:options] = pairs
 
-    %w[onboot hotplug].each do |bool_property|
-      props[bool_property] = (props[bool_property] == 'yes') if props[bool_property]
+    %i[onboot hotplug].each do |bool_property|
+      props[bool_property] = (props[bool_property] == 'yes') unless props[bool_property].nil?
     end
 
     props[:method] = 'static' unless %w[bootp dhcp].include? props[:method]
@@ -214,8 +214,8 @@ Puppet::Type.type(:network_config).provide(:redhat) do
   def self.unmunge(props)
     pairs = {}
 
-    %w[onboot hotplug].each do |bool_property|
-      if props[bool_property]
+    %i[onboot hotplug].each do |bool_property|
+      unless props[bool_property].nil?
         props[bool_property] = (props[bool_property] == true ? 'yes' : 'no')
       end
     end

--- a/spec/unit/provider/network_config/redhat_spec.rb
+++ b/spec/unit/provider/network_config/redhat_spec.rb
@@ -59,7 +59,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
     describe 'the onboot property' do
       let(:data) { described_class.parse_file('eth0', fixture_data('eth0-dhcp'))[0] }
 
-      it { expect(data[:onboot]).to eq('yes') }
+      it { expect(data[:onboot]).to be(true) }
     end
 
     describe 'the method property' do
@@ -80,13 +80,13 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       describe 'when true' do
         let(:data) { described_class.parse_file('eth0', fixture_data('eth0-hotplug'))[0] }
 
-        it { expect(data[:hotplug]).to eq('yes') }
+        it { expect(data[:hotplug]).to be(true) }
       end
 
       describe 'when false' do
         let(:data) { described_class.parse_file('eth0', fixture_data('eth0-nohotplug'))[0] }
 
-        it { expect(data[:hotplug]).to eq('no') }
+        it { expect(data[:hotplug]).to be(false) }
       end
     end
 
@@ -120,7 +120,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       describe 'bond0' do
         subject { described_class.instances.find { |i| i.name == 'bond0' } }
 
-        its(:onboot) { is_expected.to eq('yes') }
+        its(:onboot) { is_expected.to be(true) }
         its(:mtu)    { is_expected.to eq('1500') }
 
         its(:options) do
@@ -133,7 +133,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       describe 'bond1' do
         subject { described_class.instances.find { |i| i.name == 'bond1' } }
 
-        its(:onboot)    { is_expected.to eq('yes') }
+        its(:onboot)    { is_expected.to be(true) }
         its(:ipaddress) { is_expected.to eq('172.20.1.9') }
         its(:netmask)   { is_expected.to eq('255.255.255.0') }
         its(:mtu)       { is_expected.to eq('1500') }
@@ -148,7 +148,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       describe 'eth0' do
         subject { described_class.instances.find { |i| i.name == 'eth0' } }
 
-        its(:onboot) { is_expected.to eq('yes') }
+        its(:onboot) { is_expected.to be(true) }
         its(:mtu)    { is_expected.to eq('1500') }
         its(:mode)   { is_expected.to eq(:raw) }
 
@@ -164,7 +164,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       describe 'eth1' do
         subject { described_class.instances.find { |i| i.name == 'eth1' } }
 
-        its(:onboot) { is_expected.to eq('yes') }
+        its(:onboot) { is_expected.to be(true) }
         its(:mtu)    { is_expected.to eq('1500') }
         its(:mode)   { is_expected.to eq(:raw) }
 
@@ -180,7 +180,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       describe 'eth2' do
         subject { described_class.instances.find { |i| i.name == 'eth2' } }
 
-        its(:onboot) { is_expected.to eq('yes') }
+        its(:onboot) { is_expected.to be(true) }
         its(:mtu)    { is_expected.to eq('1500') }
         its(:mode)   { is_expected.to eq(:raw) }
 
@@ -196,7 +196,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       describe 'eth3' do
         subject { described_class.instances.find { |i| i.name == 'eth3' } }
 
-        its(:onboot) { is_expected.to eq('yes') }
+        its(:onboot) { is_expected.to be(true) }
         its(:mtu)    { is_expected.to eq('1500') }
         its(:mode)   { is_expected.to eq(:raw) }
 
@@ -316,7 +316,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       describe 'eth0.0' do
         subject { described_class.instances.find { |i| i.name == 'eth0.0' } }
 
-        its(:onboot) { is_expected.to eq('yes') }
+        its(:onboot) { is_expected.to be(true) }
         its(:method) { is_expected.to eq('static') }
         its(:mtu)    { is_expected.to eq('9000') }
         its(:mode)   { is_expected.to eq(:vlan) }
@@ -334,7 +334,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       describe 'eth0.1' do
         subject { described_class.instances.find { |i| i.name == 'eth0.1' } }
 
-        its(:onboot) { is_expected.to eq('yes') }
+        its(:onboot) { is_expected.to be(true) }
         its(:method) { is_expected.to eq('static') }
         its(:mtu)    { is_expected.to eq('9000') }
         its(:mode)   { is_expected.to eq(:vlan) }
@@ -352,7 +352,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       describe 'eth0.4095' do
         subject { described_class.instances.find { |i| i.name == 'eth0.4095' } }
 
-        its(:onboot) { is_expected.to eq('yes') }
+        its(:onboot) { is_expected.to be(true) }
         its(:method) { is_expected.to eq('static') }
         its(:mtu)    { is_expected.to eq('9000') }
         its(:mode)   { is_expected.to eq(:vlan) }
@@ -380,7 +380,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       instance_double('eth0_provider',
                       name: 'eth0',
                       ensure: :present,
-                      onboot: 'yes',
+                      onboot: true,
                       hotplug: true,
                       family: 'inet',
                       method: 'none',
@@ -395,7 +395,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       instance_double('eth0_1_provider',
                       name: 'eth0.1',
                       ensure: :present,
-                      onboot: 'yes',
+                      onboot: true,
                       hotplug: true,
                       family: 'inet',
                       method: 'none',
@@ -424,7 +424,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
     let(:lo_provider) do
       instance_double('lo_provider',
                       name: 'lo',
-                      onboot: 'yes',
+                      onboot: true,
                       hotplug: true,
                       family: 'inet',
                       method: 'loopback',


### PR DESCRIPTION
The props hash is using symbol keys so the previous behavior was never actually munging and unmunging those boolean values

BEFORE:

ONBOOT=true

AFTER:

ONBOOT=yes

