### PR TITLE
Move Ruby compact_hash function to Puppet code

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -22,7 +22,8 @@
 
 ### Functions
 
-* [`compact_hash`](#compact_hash): compact_hash ============  Compresses a hash to remove all elements whose values are nil or undef.  Examples --------  $example = {   'one'  
+* [`compact_hash`](#compact_hash): Compresses a hash to remove all elements whose values are nil or undef.
+* [`network::compact_hash`](#network--compact_hash): Compresses a hash by removing all elements whose values are `undef`
 
 ## Classes
 
@@ -889,41 +890,59 @@ usually discover the appropriate provider for your platform.
 
 Type: Ruby 3.x API
 
-compact_hash
-============
-
 Compresses a hash to remove all elements whose values are nil or undef.
 
-Examples
---------
-
-$example = {
-  'one'  => 'two',
-  'red'  => undef,
-  'blue' => nil,
-}
-
-compact_hash($example)
-# => { 'one => 'two' }
+* **DEPRECATED** This function is deprecated. Use the network::compact_hash() function instead.
 
 #### `compact_hash()`
 
-compact_hash
-============
-
 Compresses a hash to remove all elements whose values are nil or undef.
 
-Examples
---------
+Returns: `Any`
 
+### <a name="network--compact_hash"></a>`network::compact_hash`
+
+Type: Puppet Language
+
+Compresses a hash by removing all elements whose values are `undef`
+
+#### Examples
+
+##### 
+
+```puppet
 $example = {
   'one'  => 'two',
   'red'  => undef,
-  'blue' => nil,
 }
 
-compact_hash($example)
+network::compact_hash($example)
 # => { 'one => 'two' }
+```
 
-Returns: `Any`
+#### `network::compact_hash(Hash $hash)`
+
+The network::compact_hash function.
+
+Returns: `Hash` A new hash with all `undef` values removed
+
+##### Examples
+
+###### 
+
+```puppet
+$example = {
+  'one'  => 'two',
+  'red'  => undef,
+}
+
+network::compact_hash($example)
+# => { 'one => 'two' }
+```
+
+##### `hash`
+
+Data type: `Hash`
+
+The hash to compact
 

--- a/functions/compact_hash.pp
+++ b/functions/compact_hash.pp
@@ -1,0 +1,16 @@
+# @summary Compresses a hash by removing all elements whose values are `undef`
+#
+# @param hash The hash to compact
+# @return A new hash with all `undef` values removed
+# @example
+#   $example = {
+#     'one'  => 'two',
+#     'red'  => undef,
+#   }
+# 
+#   network::compact_hash($example)
+#   # => { 'one => 'two' }
+function network::compact_hash(Hash $hash) >> Hash {
+  # Use the built-in `filter` function to remove all elements with `undef` values
+  $hash.filter |$key, $value| { $value != undef }
+}

--- a/lib/puppet/parser/functions/compact_hash.rb
+++ b/lib/puppet/parser/functions/compact_hash.rb
@@ -1,27 +1,35 @@
+# @summary Compresses a hash to remove all elements whose values are nil or undef
+#
+# @deprecated This function is deprecated. Use the network::compact_hash() function instead.
+#
+# This function compresses a hash to remove all elements whose values are nil or undef.
+# It has been deprecated in favor of the network::compact_hash() function which provides
+# the same functionality using modern Puppet function syntax.
+#
+# @param hash The hash to compress
+# @return [Hash] A new hash with nil and undef values removed
+#
+# @example Compressing a hash
+#   $example = {
+#     'one'  => 'two',
+#     'red'  => undef,
+#     'blue' => nil,
+#   }
+#
+#   compact_hash($example)
+#   # => { 'one' => 'two' }
+#
 Puppet::Parser::Functions.newfunction(:compact_hash,
                                       type: :rvalue,
                                       arity: 1,
                                       doc: <<-EOD) do |args|
-  compact_hash
-  ============
+  @deprecated This function is deprecated. Use the network::compact_hash() function instead.
 
   Compresses a hash to remove all elements whose values are nil or undef.
-
-  Examples
-  --------
-
-  $example = {
-    'one'  => 'two',
-    'red'  => undef,
-    'blue' => nil,
-  }
-
-  compact_hash($example)
-  # => { 'one => 'two' }
-
                                       EOD
 
-  hash = args[0]
+  Puppet.deprecation_warning('compact_hash() is deprecated. Use network::compact_hash() instead.')
 
-  hash.reject { |_, val| val.nil? || val == :undef }
+  # Call the new network::compact_hash function
+  call_function('network::compact_hash', args)
 end

--- a/manifests/bond/debian.pp
+++ b/manifests/bond/debian.pp
@@ -88,7 +88,7 @@ define network::bond::debian (
     $raw_post_up = {}
   }
 
-  $opts = compact_hash(merge($raw, $raw_post_up, $options))
+  $opts = network::compact_hash(merge($raw, $raw_post_up, $options))
 
   network_config { $name:
     ensure    => $ensure,

--- a/spec/functions/compact_hash_spec.rb
+++ b/spec/functions/compact_hash_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'compact_hash' do
+  it 'returns an empty hash when given an empty hash' do
+    is_expected.to run.with_params({}).and_return({})
+  end
+
+  it 'returns a compacted hash with nil values removed' do
+    is_expected.to run.
+      with_params('key1' => 'value1', 'key2' => nil, 'key3' => '', 'key4' => false, 'key5' => true).
+      and_return('key1' => 'value1', 'key3' => '', 'key4' => false, 'key5' => true)
+  end
+end

--- a/spec/functions/network/compact_hash_spec.rb
+++ b/spec/functions/network/compact_hash_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'network::compact_hash' do
+  it 'returns an empty hash when given an empty hash' do
+    is_expected.to run.with_params({}).and_return({})
+  end
+
+  it 'returns a compacted hash with nil values removed' do
+    is_expected.to run.
+      with_params('key1' => 'value1', 'key2' => nil, 'key3' => '', 'key4' => false, 'key5' => true).
+      and_return('key1' => 'value1', 'key3' => '', 'key4' => false, 'key5' => true)
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
Move Ruby compact_hash function to Puppet code

Also update documentation.

#### This Pull Request (PR) fixes the following issues
N/A
